### PR TITLE
fix: Use SPDX code for GPLv2+

### DIFF
--- a/rhc-worker-playbook.spec.rpkg
+++ b/rhc-worker-playbook.spec.rpkg
@@ -4,7 +4,7 @@ Name:       {{{ git_dir_name }}}
 Version:    {{{ git_dir_version }}}
 Release:    1%{?dist}
 Summary:    Python worker for Red Hat connector that launches Ansible Runner
-License:    GPLv2+
+License:    GPL-2.0-or-later
 URL:        https://github.com/redhatinsights/rhc-worker-playbook
 Source:     {{{ git_dir_pack }}}
 


### PR DESCRIPTION
* Use SPDX code GPL-2.0-or-later in template of .spec file