### PR TITLE
style: format files with black and fix warnings

### DIFF
--- a/.github/workflows/stylish.yml
+++ b/.github/workflows/stylish.yml
@@ -24,10 +24,11 @@ jobs:
     - uses: psf/black@stable
       with:
         version: "24.3.0"
+        options: "--extend-exclude=yggdrasil_pb2.*.py"
 
     - name: Setup flake8 annotations
       uses: rbialon/flake8-annotations@v1
 
     - name: Run flake8
       run: |
-        flake8
+        flake8 --exclude=yggdrasil_pb2_grpc.py,yggdrasil_pb2.py --ignore=E501,E402

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist
 libexec
 rhc_ansible_worker/contrib
 *.egg-info
+rhc_worker_playbook/constants.py
+scripts/rhc-worker-playbook.worker

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include Makefile
 include vendor/*
 include rhc-worker-playbook.toml
+include rhc_worker_playbook/constants.py.in
+include scripts/rhc-worker-playbook.worker.in

--- a/rhc-worker-playbook.spec
+++ b/rhc-worker-playbook.spec
@@ -62,8 +62,7 @@ export GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY=True
 
 %define _lto_cflags %{nil}
 %set_build_flags
-%{__make} PREFIX=%{_prefix} LIBDIR=%{_libdir} CONFIG_DIR=%{rhc_config_dir} PYTHON_PKGDIR=%{python3_sitelib} installed-lib-dir
-%{make_build} build
+%{make_build} PREFIX=%{_prefix} LIBDIR=%{_libdir} CONFIG_DIR=%{rhc_config_dir} PYTHON_PKGDIR=%{python3_sitelib} build
 
 # Building the Ansible Collections
 pushd community.general-%{community_general_version}

--- a/rhc_worker_playbook/constants.py
+++ b/rhc_worker_playbook/constants.py
@@ -1,8 +1,0 @@
-import os
-WORKER_LIB_DIR = os.path.join(os.path.dirname(__file__), "contrib")
-CONFIG_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), "rhc-worker-playbook.toml")
-ANSIBLE_COLLECTIONS_PATHS = "/usr/share/rhc-worker-playbook/ansible/collections/ansible_collections/"
-# The path to the directory where artifacts should live.
-RUNNER_ARTIFACTS_DIR = "/var/log/rhc-worker-playbook/ansible"
-# Number of artifact directories we want to keep at most.
-RUNNER_ROTATE_ARTIFACTS = 100

--- a/rhc_worker_playbook/constants.py.in
+++ b/rhc_worker_playbook/constants.py.in
@@ -1,0 +1,11 @@
+import os
+
+WORKER_LIB_DIR = "@WORKER_LIB_DIR@"
+CONFIG_FILE = "@CONFIG_FILE@"
+ANSIBLE_COLLECTIONS_PATHS = (
+    "/usr/share/rhc-worker-playbook/ansible/collections/ansible_collections/"
+)
+# The path to the directory where artifacts should live.
+RUNNER_ARTIFACTS_DIR = "/var/log/rhc-worker-playbook/ansible"
+# Number of artifact directories we want to keep at most.
+RUNNER_ROTATE_ARTIFACTS = 100

--- a/rhc_worker_playbook/dispatcher_events.py
+++ b/rhc_worker_playbook/dispatcher_events.py
@@ -1,6 +1,7 @@
-'''
+"""
 Event-generating functions for the Playbook Dispatcher
-'''
+"""
+
 import uuid
 
 
@@ -13,14 +14,14 @@ def executor_on_start(correlation_id=None, stdout=None):
         "stdout": stdout,
         "start_line": 0,
         "end_line": 0,
-        "event_data": {
-            "crc_dispatcher_correlation_id": correlation_id
-        }
+        "event_data": {"crc_dispatcher_correlation_id": correlation_id},
     }
 
 
 # required event for cloud connector
-def executor_on_failed(correlation_id=None, stdout=None, error_code=None, error_details=None):
+def executor_on_failed(
+    correlation_id=None, stdout=None, error_code=None, error_details=None
+):
     return {
         "event": "executor_on_failed",
         "uuid": str(uuid.uuid4()),
@@ -31,6 +32,6 @@ def executor_on_failed(correlation_id=None, stdout=None, error_code=None, error_
         "event_data": {
             "crc_dispatcher_correlation_id": correlation_id,
             "crc_dispatcher_error_code": error_code,
-            "crc_dispatcher_error_details": error_details
-        }
+            "crc_dispatcher_error_details": error_details,
+        },
     }

--- a/scripts/rhc-worker-playbook.worker.in
+++ b/scripts/rhc-worker-playbook.worker.in
@@ -1,8 +1,9 @@
 #!/usr/libexec/platform-python
 import sys
-sys.path.insert(1, "@PYTHON_PKGDIR@")
+
+sys.path.insert(1, "/usr/lib/python3.6/site-packages")
 sys.dont_write_bytecode = True
 from rhc_worker_playbook import server
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     server.serve()

--- a/scripts/rhc-worker-playbook.worker.in
+++ b/scripts/rhc-worker-playbook.worker.in
@@ -1,6 +1,6 @@
 #!/usr/libexec/platform-python
 import sys
-sys.path.insert(1, "/usr/lib/python3.6/site-packages")
+sys.path.insert(1, "@PYTHON_PKGDIR@")
 sys.dont_write_bytecode = True
 from rhc_worker_playbook import server
 


### PR DESCRIPTION
Format files using black, fix legitimate linting warnings, ignoring a couple that we regularly violate. This PR also includes a commit that refactors the `Makefile`. The commit drops the phony targets "install-lib-dir" and "dev-lib-dir", replacing them with a more traditional "in-template" target. This commit is included in this PR because the formatting attempted to format `constants.py`. Subsequently, when the makefile was invoked, the "install-lib-dir" target would further modify `constants.py`, breaking it, and consequently breaking the build.