### PR TITLE
fix: export PYTHONDONTWRITEBYTECODE=1 when running playbooks (go)

### DIFF
--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -211,6 +211,7 @@ func RunPlaybook(id string, playbook []byte, correlationID string) (chan Event, 
 		[]string{
 			"PATH=/sbin:/bin:/usr/sbin:/usr/bin",
 			"PYTHONPATH=" + filepath.Join(constants.LibDir, "rhc-worker-playbook"),
+			"PYTHONDONTWRITEBYTECODE=1",
 			"ANSIBLE_COLLECTIONS_PATH=" + filepath.Join(
 				constants.DataDir,
 				"rhc-worker-playbook",


### PR DESCRIPTION
`PYTHONDONTWRITEBYTECODE=1` makes Python not write `.pyc` cache files, or `__pycache__` directories. This way there will be no local files written during the execution of a playbook.

Apply commit b2d7a5b39760646839a48417c3fe5c717b5df699 that was lost in the Go rewrite.