### PR TITLE
ci: fix dist workflow

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -4,17 +4,20 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:latest
     steps:
+      - run: dnf install --setopt install_weak_deps=False --assumeyes golang git-core meson 'python3dist(pip)' 'pkgconfig(yggdrasil)' 'pkgconfig(dbus-1)' 'pkgconfig(systemd)' jq ansible-core
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "stable"
-      - run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev meson
-      - run: meson setup -Dvendor=True _build && meson dist -C _build
+      # See https://github.com/mesonbuild/meson/pull/13637
+      - run: git config --global safe.directory "*"
+      - run: meson setup -Dvendor=True _build
+      - run: meson dist -C _build
       - uses: softprops/action-gh-release@v2
         with:
-          files: _build/meson-dist/rhc-worker-playbook-*.tar.xz
+          files: _build/meson-dist/rhc-worker-playbook-*.tar.xz*

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,10 @@ dbus = dependency('dbus-1', version: '>=1.12')
 systemd = dependency('systemd', version: '>=239')
 yggdrasil = dependency('yggdrasil', version: '>=0.4.2')
 
+if get_option('vendor')
+  meson.add_dist_script(join_paths('build-aux', 'vendor.sh'))
+endif
+
 goldflags = get_option('goldflags')
 goldflags += ' -X "github.com/redhatinsights/rhc-worker-playbook/internal/constants.Version=' + meson.project_version() + '"'
 goldflags += ' -X "github.com/redhatinsights/rhc-worker-playbook/internal/constants.PrefixDir=' + get_option('prefix') + '"'


### PR DESCRIPTION
Build the dist tarball on Fedora to pull in yggdrasil dependency.

Include vendor.sh dist script when build option vendor=True.