### PR TITLE
Compatibility fixes for remediations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,9 @@ This can then be piped to `pub` to publish the message:
 
 ```console 
 echo '"http://localhost:8000/insights_remove.yml"' | \
-  yggctl generate data-message --directive rhc_worker_playbook - | \
+  yggctl generate data-message \
+  --metadata '{"return_url": "http://localhost:8000/", "crc_dispatcher_correlation_id": "insights_remove"}' \
+  --directive rhc_worker_playbook - | \
   pub -broker tcp://localhost:1883 -topic yggdrasil/$(cat /var/lib/yggdrasil/client-id)/data/in
 ```
 

--- a/dist/srpm/rhc-worker-playbook.spec.in
+++ b/dist/srpm/rhc-worker-playbook.spec.in
@@ -49,7 +49,7 @@ the local host.}
 %global godocs          CONTRIBUTING.md README.md
 
 Name:               rhc-worker-playbook
-Release:            0%{?dist}
+Release:            99%{?dist}
 Summary:            Ansible playbook yggdrasil worker
 
 License:            GPL-2.0-or-later

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -121,6 +121,7 @@ func RunPlaybook(id string, playbook []byte, correlationID string) (chan json.Ra
 						if _, has := eventData.(map[string]interface{})["crc_dispatcher_correlation_id"]; !has {
 							eventData.(map[string]interface{})["crc_dispatcher_correlation_id"] = correlationID
 						}
+						eventData.(map[string]interface{})["crc_message_version"] = 1
 						event["event_data"] = eventData
 
 						// "counter" is a required field according to

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -201,7 +201,9 @@ func RunPlaybook(id string, playbook []byte, correlationID string) (chan json.Ra
 							continue
 						}
 						events <- json.RawMessage(data)
+						return
 					case "successful":
+						return
 					default:
 						log.Errorf("unsupported status case: %v", string(data))
 					}

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -95,7 +95,8 @@ func RunPlaybook(id string, playbook []byte, correlationID string) (chan json.Ra
 				log.Debugf("notify event: event=%v path=%v", e.Event(), e.Path())
 				switch e.Event() {
 				case notify.InMovedTo:
-					if strings.HasSuffix(e.Path(), ".json") {
+					if strings.HasSuffix(e.Path(), ".json") &&
+						!strings.Contains(e.Path(), "partial") {
 						data, err := os.ReadFile(e.Path())
 						if err != nil {
 							log.Errorf("cannot read file: file=%v error=%v", e.Path(), err)

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -230,7 +230,6 @@ func RunPlaybook(id string, playbook []byte, correlationID string) (chan json.Ra
 			"run",
 			"--ident",
 			id,
-			"--json",
 			"--playbook",
 			filepath.Join(constants.StateDir, id+".yaml"),
 			privateDataDir,

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -211,13 +211,6 @@ func RunPlaybook(id string, playbook []byte, correlationID string) (chan json.Ra
 		// does, clean up.
 		err := exec.WaitProcess(pid, func(pid int, state *os.ProcessState) {
 			log.Debugf("process stopped: pid=%v runner_ident=%v", pid, id)
-			if err := os.Remove(filepath.Join(constants.StateDir, id+".yaml")); err != nil {
-				log.Errorf(
-					"cannot remove file: file=%v error=%v",
-					filepath.Join(constants.StateDir, id+".yaml"),
-					err,
-				)
-			}
 			wg.Wait()
 			close(events)
 		})

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -209,8 +209,8 @@ func RunPlaybook(id string, playbook []byte, correlationID string) (chan json.Ra
 
 		// Block the remainder of the routine until the process exits. When it
 		// does, clean up.
-		err := exec.WaitProcess(pid, func(pid int, state *os.ProcessState) {
-			log.Debugf("process stopped: pid=%v runner_ident=%v", pid, id)
+		err = exec.WaitProcess(pid, func(pid int, state *os.ProcessState) {
+			log.Debugf("process stopped: pid=%v runner_ident=%v exit=%v", pid, id, state.ExitCode())
 			wg.Wait()
 			close(events)
 		})

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -164,9 +164,9 @@ func RunPlaybook(id string, playbook []byte, correlationID string) (chan json.Ra
 		defer notify.Stop(statusFileChan)
 		defer close(statusFileChan)
 		go func(c chan notify.EventInfo) {
-			log.Tracef("start goroutine watching status file: %v", jobEventsDir)
-			defer log.Tracef("stop goroutine watching status file: %v", jobEventsDir)
 			defer wg.Done()
+			log.Tracef("start goroutine watching status file: %v", statusFilePath)
+			defer log.Tracef("stop goroutine watching status file: %v", statusFilePath)
 
 			for e := range c {
 				log.Debugf("notify event: event=%v path=%v", e.Event(), e.Path())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,10 +1,13 @@
 package config
 
+import "time"
+
 const (
 	FlagNameDirective            = "directive"
 	FlagNameInsightsCoreGPGCheck = "insights-core-gpg-check"
 	FlagNameLogLevel             = "log-level"
 	FlagNameVerifyPlaybook       = "verify-playbook"
+	FlagNameResponseInterval     = "response-interval"
 )
 
 type Config struct {
@@ -21,6 +24,10 @@ type Config struct {
 	// VerifyPlaybook determines whether or not to verify incoming playbooks'
 	// GPG signatures.
 	VerifyPlaybook bool
+
+	// ResponseInterval overrides the response interval value set in the
+	// message, instead always setting it to this value.
+	ResponseInterval time.Duration
 }
 
 // DefaultConfig is a globally accessible Config data structure, initialized
@@ -30,4 +37,5 @@ var DefaultConfig = Config{
 	InsightsCoreGPGCheck: true,
 	LogLevel:             "error",
 	VerifyPlaybook:       true,
+	ResponseInterval:     0,
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ const (
 	FlagNameLogLevel             = "log-level"
 	FlagNameVerifyPlaybook       = "verify-playbook"
 	FlagNameResponseInterval     = "response-interval"
+	FlagNameBatchEvents          = "batch-events"
 )
 
 type Config struct {
@@ -28,6 +29,10 @@ type Config struct {
 	// ResponseInterval overrides the response interval value set in the
 	// message, instead always setting it to this value.
 	ResponseInterval time.Duration
+
+	// BatchEvents is the number of events to batch together in a given transmit
+	// response.
+	BatchEvents int
 }
 
 // DefaultConfig is a globally accessible Config data structure, initialized
@@ -38,4 +43,5 @@ var DefaultConfig = Config{
 	LogLevel:             "error",
 	VerifyPlaybook:       true,
 	ResponseInterval:     0,
+	BatchEvents:          0,
 }

--- a/main.go
+++ b/main.go
@@ -56,6 +56,12 @@ func main() {
 			Usage:  "override per-message response interval value",
 			Hidden: true,
 		}),
+		altsrc.NewIntFlag(&cli.IntFlag{
+			Name:   config.FlagNameBatchEvents,
+			Value:  config.DefaultConfig.BatchEvents,
+			Usage:  "number of events to batch together in a single transmision",
+			Hidden: true,
+		}),
 	}
 
 	app.Before = beforeAction
@@ -113,4 +119,5 @@ func loadConfigFromContext(ctx *cli.Context) {
 	config.DefaultConfig.VerifyPlaybook = ctx.Bool(config.FlagNameVerifyPlaybook)
 	config.DefaultConfig.InsightsCoreGPGCheck = ctx.Bool(config.FlagNameInsightsCoreGPGCheck)
 	config.DefaultConfig.ResponseInterval = ctx.Duration(config.FlagNameResponseInterval)
+	config.DefaultConfig.BatchEvents = ctx.Int(config.FlagNameBatchEvents)
 }

--- a/main.go
+++ b/main.go
@@ -50,6 +50,12 @@ func main() {
 			Value: config.DefaultConfig.InsightsCoreGPGCheck,
 			Usage: "perform GPG signature verification on insights-core.egg",
 		}),
+		altsrc.NewDurationFlag(&cli.DurationFlag{
+			Name:   config.FlagNameResponseInterval,
+			Value:  config.DefaultConfig.ResponseInterval,
+			Usage:  "override per-message response interval value",
+			Hidden: true,
+		}),
 	}
 
 	app.Before = beforeAction
@@ -106,4 +112,5 @@ func loadConfigFromContext(ctx *cli.Context) {
 	config.DefaultConfig.LogLevel = ctx.String(config.FlagNameLogLevel)
 	config.DefaultConfig.VerifyPlaybook = ctx.Bool(config.FlagNameVerifyPlaybook)
 	config.DefaultConfig.InsightsCoreGPGCheck = ctx.Bool(config.FlagNameInsightsCoreGPGCheck)
+	config.DefaultConfig.ResponseInterval = ctx.Duration(config.FlagNameResponseInterval)
 }

--- a/meson.build
+++ b/meson.build
@@ -14,8 +14,8 @@ goldflags += ' -X "github.com/redhatinsights/rhc-worker-playbook/internal/consta
 goldflags += ' -X "github.com/redhatinsights/rhc-worker-playbook/internal/constants.PrefixDir=' + get_option('prefix') + '"'
 goldflags += ' -X "github.com/redhatinsights/rhc-worker-playbook/internal/constants.SysconfDir=' + get_option('sysconfdir') + '"'
 goldflags += ' -X "github.com/redhatinsights/rhc-worker-playbook/internal/constants.LocalStateDir=' + get_option('localstatedir') + '"'
-goldflags += ' -X "github.com/redhatinsights/rhc-worker-playbook/internal/constants.LibDir=' + get_option('libdir') + '"'
-goldflags += ' -X "github.com/redhatinsights/rhc-worker-playbook/internal/constants.DataDir=' + get_option('datadir') + '"'
+goldflags += ' -X "github.com/redhatinsights/rhc-worker-playbook/internal/constants.LibDir=' + get_option('prefix') / get_option('libdir') + '"'
+goldflags += ' -X "github.com/redhatinsights/rhc-worker-playbook/internal/constants.DataDir=' + get_option('prefix') / get_option('datadir') + '"'
 
 gobuildflags = get_option('gobuildflags')
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,11 @@
+To update package versions in this directory:
+
+* Change the version string pinned in `requirements.in`
+* Download the wheel or tarball of the new version from pypi.org
+* Update the entry in SHA256SUM with the correct hash
+* Install `piptools` if necessary: `python -m pip install piptools`
+* Run the following command to regenerate `requirements.txt`
+
+```
+python -m piptools compile --allow-unsafe --find-links=. --generate-hashes --no-index requirements.in > requirements.txt
+```

--- a/worker.go
+++ b/worker.go
@@ -72,7 +72,8 @@ func rx(
 		data = d
 	}
 
-	events, err := ansible.RunPlaybook(id, data, correlationID)
+	runner := ansible.NewRunner(correlationID, 60*time.Second)
+	err = runner.Run(data)
 	if err != nil {
 		return fmt.Errorf("cannot run playbook: %v", err)
 	}
@@ -136,7 +137,7 @@ func rx(
 			}
 		}()
 
-		for event := range events {
+		for event := range runner.Events {
 			log.Debugf("ansible-runner event: %s", event)
 
 			lock.Lock()
@@ -162,8 +163,8 @@ func rx(
 				continue
 			}
 		}
-		// The "events" channel will be closed when the RunPlaybook function has
-		// finished handling ansible-runner events. At this point, signal the
+		// The "events" channel will be closed when the Run method has finished
+		// handling ansible-runner events. At this point, signal the
 		// responseInterval goroutine to exit.
 		done <- struct{}{}
 


### PR DESCRIPTION
A series of behavior changes to better interact with console-dot services. This PR introduces two new hidden flags: `--response-interval` and `--batch-events`. The former can be used to simply override the server-specified response interval value. The latter can be used to ignore the response interval and instead upload events in batches of the specified size. Setting a batch size to 1 effectively creates "real time" uploading of events.

The 'ansible' package was significantly rewritten as a result of the additional complexity introduced by this PR.

Card ID: [CCT-640](https://issues.redhat.com/browse/CCT-640)
Card ID: [CCT-951](https://issues.redhat.com/browse/CCT-951)