### PR TITLE
fix(test):adding rhc-worker playbook to install list for tests

### DIFF
--- a/systemtest/plans/main.fmf
+++ b/systemtest/plans/main.fmf
@@ -6,5 +6,6 @@ prepare:
       how: install
       package:
         - rhc
+        - rhc-worker-playbook
 execute:
     how: tmt


### PR DESCRIPTION
This change will fix the failing basic test that verify if packages are installed correctly.