### PR TITLE
Disable http-proxy in grpc channel

### DIFF
--- a/rhc_worker_playbook/server.py
+++ b/rhc_worker_playbook/server.py
@@ -309,7 +309,10 @@ def serve():
     config = _loadConfig()
 
     # open the channel to ygg Dispatcher
-    channel = grpc.insecure_channel(YGG_SOCKET_ADDR)
+    channel = grpc.insecure_channel(
+        YGG_SOCKET_ADDR,
+        options=[("grpc.enable_http_proxy", 0)],
+    )
     dispatcher = yggdrasil_pb2_grpc.DispatcherStub(channel)
     _log("Registering with directive %s..." % config["directive"])
     registrationResponse = dispatcher.Register(


### PR DESCRIPTION
When creating an grpc channel object, explicitly disable usage of http proxies. This prevents the channel from attempting to connect to the UNIX socket name as a TCP address.

Card ID: CCT-1185