### PR TITLE
fix: capture signature validation failures

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,7 +25,6 @@ jobs:
       - "copr://@yggdrasil/latest"
     targets:
       - centos-stream-9
-      - rhel-8
       - rhel-9
 
   - job: copr_build
@@ -35,7 +34,6 @@ jobs:
     project: latest
     targets:
       - centos-stream-9
-      - rhel-8
       - rhel-9
 
   - job: tests
@@ -55,9 +53,6 @@ jobs:
     trigger: pull_request
     identifier: "unit/rhel"
     targets:
-      rhel-8-x86_64:
-        distros:
-          - RHEL-8-Nightly
       rhel-9-x86_64:
         distros:
           - RHEL-9-Nightly

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -24,8 +24,10 @@ jobs:
     additional_repos:
       - "copr://@yggdrasil/latest"
     targets:
-      - centos-stream-9
-      - rhel-9
+      - centos-stream-9-aarch64
+      - centos-stream-9-x86_64
+      - rhel-9-aarch64
+      - rhel-9-x86_64
 
   - job: copr_build
     trigger: commit
@@ -33,8 +35,10 @@ jobs:
     owner: "@yggdrasil"
     project: latest
     targets:
-      - centos-stream-9
-      - rhel-9
+      - centos-stream-9-aarch64
+      - centos-stream-9-x86_64
+      - rhel-9-aarch64
+      - rhel-9-x86_64
 
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
When playbook signature validation fails, rather than just logging the message locally, capture the failure, package it up in a message and send back the failure notice.

Card ID: [RHEL-2485](https://issues.redhat.com/browse/RHEL-2485)