### PR TITLE
Inject SCM info into RPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ rhc_ansible_worker/contrib
 *.egg-info
 rhc_worker_playbook/constants.py
 scripts/rhc-worker-playbook.worker
+rhc-worker-playbook.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,6 +10,8 @@ srpm_build_deps:
   - rpm-build
 
 actions:
+  post-upstream-clone:
+    - make rhc-worker-playbook.spec
   get-current-version:
     - awk '/^Version:/ {print $2;}' rhc-worker-playbook.spec
   create-archive:

--- a/rhc-worker-playbook.spec.in
+++ b/rhc-worker-playbook.spec.in
@@ -3,8 +3,8 @@
 %define ansible_posix_version 1.3.0
 
 Name:       rhc-worker-playbook
-Version:    0.1.10
-Release:    0%{?dist}
+Version:    @PKGVER@
+Release:    @RELEASE@%{?dist}
 Summary:    Python worker for Red Hat connector that launches Ansible Runner
 License:    GPL-2.0-or-later
 URL:        https://github.com/redhatinsights/rhc-worker-playbook


### PR DESCRIPTION
Refactor the CI SRPM spec generation to inject version and release fields automatically. This includes the git commit in the RPM "Release" field, so that NVRs look like `rhc-worker-playbook-0.1.10-99.5.git.c0b9276.el9`.