### PR TITLE
fix: The toolchain has to exist in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/redhatinsights/rhc-worker-playbook
 
 go 1.21
 
+toolchain go1.21.0
+
 require (
 	git.sr.ht/~spc/go-log v0.1.1
 	github.com/goccy/go-yaml v1.12.0


### PR DESCRIPTION
* Since go 1.21 toolchain must follow 1.N.P syntax
* When toolchain does not exist, then some commands may fail