### PR TITLE
feat(RHINENG-18785): filter events based on playbook dispatcher schema [RHEL 8+9]

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include vendor/*
 include rhc-worker-playbook.toml
 include rhc_worker_playbook/constants.py.in
 include scripts/rhc-worker-playbook.worker.in
+include ansibleRunnerJobEvent.yml

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ install:
 	$(PYTHON) setup.py install --root=$(DESTDIR) --prefix=$(PREFIX) --install-scripts=$(LIBEXECDIR)/rhc --single-version-externally-managed --record /dev/null
 	$(PYTHON) -m pip install --target $(DESTDIR)$(LIBDIR)/$(PKGNAME) --no-index --find-links vendor vendor/*.whl
 	[[ -e $(DESTDIR)$(CONFIG_FILE) ]] || install -D -m644 ./rhc-worker-playbook.toml $(DESTDIR)$(CONFIG_FILE)
+	install -D ./ansibleRunnerJobEvent.yml $(WORKER_LIB_DIR)
 
 .PHONY: uninstall
 uninstall:

--- a/ansibleRunnerJobEvent.yml
+++ b/ansibleRunnerJobEvent.yml
@@ -1,0 +1,53 @@
+# This schema captures the shape of events produced by ansible runner
+# https://ansible-runner.readthedocs.io/en/stable/intro.html#runner-artifact-job-events-host-and-playbook-events
+# This schema does not aim to be complete - it only captures used by playbook-dispatcher
+---
+$id: ansibleRunnerJobEvent
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+properties:
+  event:
+    type: string
+    minLength: 3
+    maxLength: 50
+  uuid:
+    type: string
+    format: uuid
+  counter:
+    type: integer
+  stdout:
+    type:
+      - string
+      - "null"
+  start_line:
+    type: integer
+    minimum: 0
+  end_line:
+    type: integer
+    minimum: 0
+  event_data:
+    type: object
+    properties:
+      playbook:
+        type: string
+        minLength: 1
+      playbook_uuid:
+        type: string
+        format: uuid
+      host:
+        type: string
+
+      crc_dispatcher_correlation_id:
+        type: string
+        format: uuid
+      crc_dispatcher_error_code:
+        type: string
+      crc_dispatcher_error_details:
+        type: string
+
+required:
+  - event
+  - uuid
+  - counter
+  - start_line
+  - end_line

--- a/rhc_worker_playbook/constants.py.in
+++ b/rhc_worker_playbook/constants.py.in
@@ -2,6 +2,7 @@ import os
 
 WORKER_LIB_DIR = "@WORKER_LIB_DIR@"
 CONFIG_FILE = "@CONFIG_FILE@"
+DEFAULT_JOB_EVENT_SCHEMA_FILE = "@WORKER_LIB_DIR@/ansibleRunnerJobEvent.yml"
 ANSIBLE_COLLECTIONS_PATHS = (
     "/usr/share/rhc-worker-playbook/ansible/collections/ansible_collections/"
 )

--- a/rhc_worker_playbook/server.py
+++ b/rhc_worker_playbook/server.py
@@ -6,6 +6,7 @@ from .constants import (
     ANSIBLE_COLLECTIONS_PATHS,
     RUNNER_ARTIFACTS_DIR,
     RUNNER_ROTATE_ARTIFACTS,
+    DEFAULT_JOB_EVENT_SCHEMA_FILE
 )
 
 sys.path.insert(0, WORKER_LIB_DIR)
@@ -29,7 +30,6 @@ from .dispatcher_events import executor_on_start, executor_on_failed
 sys.stdout = os.fdopen(sys.stdout.fileno(), "wb", buffering=0)
 atexit.register(sys.stdout.close)
 
-
 def _log(message):
     """
     Send message as bytes over unbuffered stdout for
@@ -50,6 +50,8 @@ if not YGG_SOCKET_ADDR:
 YGG_SOCKET_ADDR = YGG_SOCKET_ADDR.replace("unix:@", "unix-abstract:")
 BASIC_PATH = "/sbin:/bin:/usr/sbin:/usr/bin"
 
+with open(DEFAULT_JOB_EVENT_SCHEMA_FILE) as schema_yaml:
+    DEFAULT_JOB_EVENT_SCHEMA = yaml.safe_load(schema_yaml)
 
 def _newlineDelimited(events):
     """
@@ -134,8 +136,37 @@ class Events(list):
     Extension of list to receive ansible-runner events
     """
 
-    def __init__(self):
-        pass
+    def __init__(self, eventSchema=DEFAULT_JOB_EVENT_SCHEMA):
+        # event spec from playbook dispatcher for filtering events to reduce message size
+        self.eventSchema = eventSchema
+
+    def _filterEvent(self, event, schema):
+        properties = schema.get('properties', {})
+        filteredEvent = {}
+
+        for key, value in event.items():
+            prop_schema = properties.get(key)
+            if prop_schema:
+                prop_type = prop_schema.get('type')
+
+                if prop_type == 'object':
+                    filteredEvent[key] = self._filterEvent(value, prop_schema)
+                elif prop_type == 'array':
+                    # there are currently no array types in PBD, but here for completeness' sake
+                    if isinstance(value, list):
+                        filteredEvent[key] = [
+                            self._filterEvent(item, prop_schema['items'])
+                            if prop_schema['items'].get('type') == 'object' else item
+                            for item in value
+                        ]
+                    else:
+                        # type mismatch, ignore
+                        pass
+                else:
+                    # basic type
+                    filteredEvent[key] = value
+
+        return filteredEvent
 
     def addEvent(self, event):
         try:
@@ -143,7 +174,17 @@ class Events(list):
         except AttributeError:
             # one of the fields was null/empty
             pass
-        self.append(event)
+
+        # log the full event
+        _log(str(event))
+
+        # send the filtered event back to RHC
+        self.append(self._filterEvent(event, self.eventSchema))
+        
+        # this method must return True for ansible to save job events to disk
+        #   at RUNNER_ARTIFACTS_DIR/{runId}/job_events
+        return True
+
 
 
 class WorkerService(yggdrasil_pb2_grpc.WorkerServicer):
@@ -171,7 +212,9 @@ class WorkerService(yggdrasil_pb2_grpc.WorkerServicer):
         # load configuration
         config = _loadConfig()
 
+        # TODO: initialize this with the job event schema fetched from playbook dispatcher
         events = Events()
+
         # parse playbook from data field
         try:
             # required fields


### PR DESCRIPTION
Currently, rhc-worker-playbook sends _all_ of Ansible runner's cumulative up-to-the-moment output in each upload. This can grow in size to the point that it overloads various data transmission channels (message queues, REST endpoint filesize limits, etc) and simply fails quietly, causing the remediations execution UI to falsely report "in progress" until it times out.

There are several issues to be addressed around this entire application flow, but one low hanging fruit is to reduce the amount of information being sent.

Playbook dispatcher actually only requires a handful of fields from the job event and discards most of what is uploaded: see [the Ansible job event OAPI schema](https://github.com/RedHatInsights/playbook-dispatcher/blob/master/schema/ansibleRunnerJobEvent.yaml) and [the types it generates](https://github.com/RedHatInsights/playbook-dispatcher/blob/master/internal/common/model/message/runner.types.gen.go).

This PR borrows the OAPI schema from dispatcher and uses it to filter job events down to only what is required for an upload. This PR does _not_ address the ideal case in which RHC-WP downloads or otherwise receives the schema on every run, in the (albeit unlikely) event that the schema changes.

I have also added a couple logging tweaks. Since the event contents are now reduced, it seems prudent to preserve the event via logging it to RHC and also saving the job event JSON files to disk, for debugging purposes.

An additional PR to `main` with the Go implementation of this functionality for the newest version on RHEL 10 to follow.