### PR TITLE
fix(RHINENG-19197): increase timeout, cleanup channels on timeout

### DIFF
--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -3,3 +3,4 @@ pyyaml
 sh
 paho-mqtt
 distro
+requests-toolbelt

--- a/integration-tests/resources/pause1m.yml
+++ b/integration-tests/resources/pause1m.yml
@@ -1,0 +1,5 @@
+- name: pause
+  hosts: "localhost"
+  tasks:
+    - pause:
+        minutes: 1

--- a/integration-tests/test_rhc_worker_playbook.py
+++ b/integration-tests/test_rhc_worker_playbook.py
@@ -2,6 +2,7 @@ import logging
 import os
 import subprocess
 import json
+import time
 
 import pytest
 
@@ -20,7 +21,7 @@ logger = logging.getLogger(__name__)
     reason="This test is only supported on RHEL10 and above",
 )
 def test_playbook_execution_local_broker(
-    start_http_server_localhost,
+    http_server,
     rhc_worker_test_file,
     rhc_worker_playbook_config_for_worker_test,
     yggdrasil_config_for_local_mqtt_broker,
@@ -30,10 +31,10 @@ def test_playbook_execution_local_broker(
             1. Start rhc_worker_playbook
             2. Start yggdrasil service
             3. Verify the test file does not exist
-            3. Build a MQTT message to run the playbook
-            4. Publish the message to the MQTT topic
-            5. Verify the playbook execution status
-            6. Verify the test file is created
+            4. Build a MQTT message to run the playbook
+            5. Publish the message to the MQTT topic
+            6. Verify the playbook execution status
+            7. Verify the test file is created
         expected_results:
             1. The playbook execution is successful
             2. The test file is created
@@ -62,3 +63,63 @@ def test_playbook_execution_local_broker(
         data_message["metadata"]["crc_dispatcher_correlation_id"]
     )
     assert os.path.exists(rhc_worker_test_file), "Test file not created."
+    
+    # TODO: re-add this test when the other PR is merged
+    # logger.info("Verifying job event data is being correctly filtered......")
+    
+    # assert verify_uploaded_event_runner_data_is_filtered(http_server.post_body)
+
+@pytest.mark.skipif(
+    pytest.rhel_major_version == "unknown" or int(pytest.rhel_major_version) < 10,
+    reason="This test is only supported on RHEL10 and above",
+)
+def test_playbook_execution_timeout_greater_than_one_min(
+    http_server,
+    rhc_worker_playbook_config_for_worker_test,
+    yggdrasil_config_for_local_mqtt_broker,
+):
+    """
+        test_steps:
+            1. Start rhc_worker_playbook
+            2. Start yggdrasil service
+            3. Build a MQTT message to run the playbook
+            4. Publish the message to the MQTT topic
+            5. Verify the playbook execution status
+            6. Verify that the uploads do not continue after execution completes
+        expected_results:
+            1. The playbook execution is successful
+            2. The uploads do not continue indefinitely once execution completes
+    """
+    playbook_url = "http://localhost:8000/resources/pause1m.yml"
+    repsonse_interval = 30
+
+    subprocess.run(
+        ["systemctl", "restart", "com.redhat.Yggdrasil1.Worker1.rhc_worker_playbook"]
+    )
+    subprocess.run(["systemctl", "restart", "yggdrasil"])
+
+    logger.info(f"Playbook will be downloaded from: {playbook_url}")
+    data_message = build_data_msg_for_worker_playbook(response_interval=repsonse_interval, content=playbook_url)
+    topic = mqtt_data_topic()
+
+    logger.info(f"Publishing message to MQTT broker. Topic: {topic}")
+    publish_message(topic=topic, payload=json.dumps(data_message))
+
+    logger.info("Verifying playbook execution status......")
+
+    # playbook takes 1 min to run, allow for 1 min + a little extra
+    assert verify_playbook_execution_status(
+        data_message["metadata"]["crc_dispatcher_correlation_id"], timeout=90
+    )
+
+    logger.info("Verifying the playbook doesn't upload anything more after finishing...")
+    # wait just over 30 seconds (response interval) after the playbook finishes to make sure no more uploads come in 
+    number_of_uploads_at_playbook_finish = len(http_server.request_bodies)
+    start_time = time.time()
+    while (time.time() - start_time) < repsonse_interval + 5:
+        if len(http_server.request_bodies) > number_of_uploads_at_playbook_finish:
+            # something came in after upload finished, this is a failure case
+            assert False
+        time.sleep(5)
+    # number of uploads should be unchanged from before the wait
+    assert number_of_uploads_at_playbook_finish == len(http_server.request_bodies)

--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -7,7 +7,11 @@ from datetime import datetime
 import paho.mqtt.client as mqtt
 
 
-def build_data_msg_for_worker_playbook(**data):
+def build_data_msg_for_worker_playbook(
+    response_interval=600,
+    content="http://localhost:8000/cq:qreate_file.yml",
+    **data
+):
     """
     Provides the mqtt data message in a format accepted by rhc-worker-playbook directive
     """
@@ -18,11 +22,11 @@ def build_data_msg_for_worker_playbook(**data):
         "sent": datetime.now().astimezone().replace(microsecond=0).isoformat(),
         "directive": "rhc_worker_playbook",
         "metadata": {
-            "response_interval": "600",
+            "response_interval": str(response_interval),
             "crc_dispatcher_correlation_id": str(uuid.uuid4()),
             "return_url": "http://localhost:8000/",
         },
-        "content": "http://localhost:8000/create_file.yml",
+        "content": content,
         **data,
     }
 
@@ -68,3 +72,28 @@ def verify_playbook_execution_status(crc_dispatcher_correlation_id, timeout=30):
                     return True
         time.sleep(5)
     return False
+
+# TODO: re-add once other PR is merged
+# def verify_uploaded_event_runner_data_is_filtered(req_body):
+#     """
+#     Check that the payload sent by rhc-worker-playbook is filtered down
+#     to only the required data.
+#     """
+#     json_lines = req_body.split('\n')
+#     for line in json_lines:
+#         if line == '':
+#             # request can end with newline and split results in empty string
+#             continue
+        
+#         parsed = json.loads(line)
+        
+#         # just use current known PBD schema to validate
+#         for prop in parsed:
+#             if prop not in ['event', 'uuid', 'counter', 'stdout', 'start_line', 'end_line', 'event_data']:
+#                 return False
+        
+#         for prop in parsed.get('event_data', {}):
+#             if prop not in ['playbook', 'playbook_uuid', 'host', 'crc_dispatcher_correlation_id', 'crc_dispatcher_error_code', 'crc_dispatcher_error_details']:
+#                 return False
+            
+#     return True

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -250,6 +250,11 @@ func (r *Runner) handleStatusFileEvent(event notify.EventInfo) {
 
 	r.Status = status
 
+	r.end()
+}
+
+// end monitoring playbook event output
+func (r *Runner) end() {
 	// Close the events channel, signalling to callers that the job is complete.
 	close(r.Events)
 
@@ -287,6 +292,8 @@ func (r *Runner) watch(
 		select {
 		case <-timeout:
 			log.Infof("timeout elapsed watching for events: path=%v", path)
+			// since the status file handler is not invoked, clean up channels here, otherwise it will upload forever
+			r.end()
 			return
 		case <-stop:
 			return

--- a/worker.go
+++ b/worker.go
@@ -104,7 +104,7 @@ func rx(
 	eventManager := NewEventManager(id, returnURL, responseInterval, w)
 
 	// Create the playbook runner.
-	runner := ansible.NewRunner(correlationID, 60*time.Second)
+	runner := ansible.NewRunner(correlationID, 60*time.Minute)
 
 	// Start the goroutine processing events from the runner.
 	go eventManager.processEvents(runner)


### PR DESCRIPTION
The Runner object is currently initialized with a timeout of 60 seconds, which is not enough time for a playbook run.

Upon hitting the 60 second timeout:
- the process abandons watching the `status` file that Ansible writes to
- `handleStatusFileEvent` never gets called when `status` is updated
- the `Events` channel is never closed by `handleStatusFileEvent`, leaving the `processEvents` loop to run forever
- **event data continues to upload forever, every 30 seconds even long after the playbook completes** (this is bad)

What I have done here: 
- add an extra bit to the timeout on the event watcher, where it will close the channels and send stop events like it does at the end of a playbook run
- separated those cleanup calls to a new function `end`.
- increased the timeout to 60 minutes, which is the current Remediations UI timeout for a playbook run
  - _TODO_: the timeout should perhaps be configurable