### PR TITLE
chore(ci): enable rhel-10, s390x, and ppc64le packit build targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -33,11 +33,16 @@ jobs:
     additional_repos:
       - "copr://@yggdrasil/latest"
     targets:
-      - centos-stream-9
-      - centos-stream-10
-      - fedora-all
-      - rhel-9
-      - rhel-10
+      - centos-stream-10-aarch64
+      - centos-stream-10-x86_64
+      - centos-stream-10-ppc64le
+      - centos-stream-10-s390x
+      - fedora-all-aarch64
+      - fedora-all-x86_64
+      - rhel-10-aarch64
+      - rhel-10-x86_64
+      - rhel-10-ppc64le
+      - rhel-10-s390x
 
   - job: copr_build
     trigger: commit
@@ -45,20 +50,21 @@ jobs:
     owner: "@yggdrasil"
     project: latest
     targets:
-      - centos-stream-9-aarch64
-      - centos-stream-9-x86_64
       - centos-stream-10-aarch64
       - centos-stream-10-x86_64
+      - centos-stream-10-ppc64le
+      - centos-stream-10-s390x
       - fedora-all-aarch64
       - fedora-all-x86_64
-      - rhel-9-aarch64
-      - rhel-9-x86_64
+      - rhel-10-aarch64
+      - rhel-10-x86_64
+      - rhel-10-ppc64le
+      - rhel-10-s390x
 
   - job: tests
     trigger: pull_request
     identifier: "unit/centos-stream"
     targets:
-      - centos-stream-9
       - centos-stream-10
     labels:
       - unit
@@ -85,9 +91,6 @@ jobs:
     trigger: pull_request
     identifier: "unit/rhel"
     targets:
-      rhel-9-x86_64:
-        distros:
-          - RHEL-9-Nightly
       rhel-10-x86_64:
         distros:
           - RHEL-10-Nightly


### PR DESCRIPTION
* Card ID: CCT-1407
* Added rhel-10 build targets
* Added targets for s390x and ppc64le architectures
* Removed rhel-9 and centos-stream-9 targets