### PR TITLE
fix(test): Fix unspecified protocol in yggdrasil config

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -94,6 +94,7 @@ def yggdrasil_config_for_local_mqtt_broker():
     shutil.copyfile(config_path, backup_path)
 
     config = toml.load(config_path)
+    config["protocol"] = "mqtt"
     config["server"] = ["tcp://localhost:1883"]
     config["data-host"] = "localhost:8000"
     config["cert-file"] = ""


### PR DESCRIPTION
Tests are failing due to unspecified protocol in yggdrasil config.toml. 
Tests upstream uses copr builds of yggdrasil and those builds have empty config.toml files as below (values are commented out )
```
cat /etc/yggdrasil/config.toml.rpmnew 
# yggdrasil global configuration settings
#
# protocol = "mqtt"
# server = ["tcp://test.mosquitto.org:1883"]
# log-level = "error"

```