### PR TITLE
refactor(RHINENG-21857): overhaul logging to use slog 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/redhatinsights/yggdrasil v0.4.9
 	github.com/rjeczalik/notify v0.9.3
-	github.com/subpop/go-log v0.1.2
 	github.com/urfave/cli/v2 v2.27.7
 )
 
@@ -17,6 +16,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/subpop/go-log v0.1.2 // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -124,7 +124,7 @@ def verify_playbook_verification_success_log(timeout=30):
     """
     start_time = time.time()
     while (time.time() - start_time) < timeout:
-        if _is_in_journald_grep("Playbook verified."):
+        if _is_in_journald_grep("playbook verified"):
             return True
         time.sleep(5)
     return False

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -10,11 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"log/slog"
+
 	"github.com/google/uuid"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/constants"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/exec"
 	"github.com/rjeczalik/notify"
-	"github.com/subpop/go-log"
 )
 
 // Runner maintains the state of a playbook run during execution.
@@ -60,6 +61,8 @@ func NewRunner(ID string, timeout time.Duration) *Runner {
 func (r *Runner) Run(playbook []byte) error {
 	// write playbook to the filesystem
 	playbookPath := filepath.Join(constants.StateDir, r.ID+".yaml")
+	slog.Info("writing playbook to file:", "path", playbookPath)
+
 	if err := os.WriteFile(playbookPath, playbook, 0600); err != nil {
 		return fmt.Errorf("cannot write playbook file: path=%v err=%w", playbookPath, err)
 	}
@@ -67,6 +70,8 @@ func (r *Runner) Run(playbook []byte) error {
 	// precreate the job_events directory so that we can watch for when events
 	// get written to it.
 	jobEventsPath := filepath.Join(r.privateDataDir, "artifacts", r.ID, "job_events")
+	slog.Info("creating job_events directory:", "path", jobEventsPath)
+
 	if err := os.MkdirAll(jobEventsPath, 0755); err != nil {
 		return fmt.Errorf(
 			"cannot create job_events directory: directory=%v err=%w",
@@ -78,6 +83,8 @@ func (r *Runner) Run(playbook []byte) error {
 	// precreate the status file so that we can watch for when it gets written
 	// to.
 	statusFilePath := filepath.Join(r.privateDataDir, "artifacts", r.ID, "status")
+	slog.Info("writing status file:", "path", statusFilePath)
+
 	status, err := os.Create(statusFilePath)
 	if err != nil {
 		return fmt.Errorf("cannot create status file: file=%v err=%w", statusFilePath, err)
@@ -109,7 +116,7 @@ func (r *Runner) Run(playbook []byte) error {
 		event := GenerateExecutorOnStartEvent(r.ID, uuid.New)
 		data, err := json.Marshal(event)
 		if err != nil {
-			log.Errorf("cannot marshal json: err=%v", err)
+			slog.Error("cannot marshal json:", "err", err)
 			return
 		}
 		r.Events <- data
@@ -123,34 +130,43 @@ func (r *Runner) Run(playbook []byte) error {
 	// created automatically by ansible_runner
 	ansibleRemoteTmpPath := filepath.Join(ansibleHomePath, "remote-tmp")
 
+	args := []string{
+		"-m",
+		"ansible_runner",
+		"start",
+		"--ident",
+		r.ID,
+		"--playbook",
+		playbookPath,
+		r.privateDataDir,
+	}
+	env := []string{
+		"PATH=/sbin:/bin:/usr/sbin:/usr/bin",
+		"PYTHONPATH=" + filepath.Join(constants.LibDir, "rhc-worker-playbook"),
+		"PYTHONDONTWRITEBYTECODE=1",
+		"ANSIBLE_HOME=" + ansibleHomePath,
+		"ANSIBLE_REMOTE_TMP=" + ansibleRemoteTmpPath,
+		"ANSIBLE_COLLECTIONS_PATH=" + filepath.Join(
+			constants.DataDir,
+			"rhc-worker-playbook",
+			"ansible",
+			"collections",
+			"ansible_collections",
+		),
+	}
+
+	slog.Info("launching python3 (ansible-runner) subprocess")
+	slog.Debug("launching with parameters:",
+		"args", args,
+		"env", env,
+	)
+
 	err = exec.StartProcess(
 		"/usr/bin/python3",
-		[]string{
-			"-m",
-			"ansible_runner",
-			"start",
-			"--ident",
-			r.ID,
-			"--playbook",
-			playbookPath,
-			r.privateDataDir,
-		},
-		[]string{
-			"PATH=/sbin:/bin:/usr/sbin:/usr/bin",
-			"PYTHONPATH=" + filepath.Join(constants.LibDir, "rhc-worker-playbook"),
-			"PYTHONDONTWRITEBYTECODE=1",
-			"ANSIBLE_HOME=" + ansibleHomePath,
-			"ANSIBLE_REMOTE_TMP=" + ansibleRemoteTmpPath,
-			"ANSIBLE_COLLECTIONS_PATH=" + filepath.Join(
-				constants.DataDir,
-				"rhc-worker-playbook",
-				"ansible",
-				"collections",
-				"ansible_collections",
-			),
-		},
+		args,
+		env,
 		func(pid int, stdout, stderr io.ReadCloser) {
-			log.Infof("run started: pid=%v", pid)
+			slog.Info("run started:", "pid", pid)
 		},
 	)
 
@@ -164,10 +180,13 @@ func (r *Runner) Run(playbook []byte) error {
 // handleJobEvent is the handler function invoked each time a job_event file is
 // written to the job_events directory.
 func (r *Runner) handleJobEvent(event notify.EventInfo) {
-	if strings.HasSuffix(event.Path(), ".json") && !strings.Contains(event.Path(), "partial") {
-		data, err := os.ReadFile(event.Path())
+	eventPath := event.Path()
+	if strings.HasSuffix(eventPath, ".json") && !strings.Contains(eventPath, "partial") {
+		data, err := os.ReadFile(eventPath)
 		if err != nil {
-			log.Errorf("cannot read file: file=%v error=%v", event.Path(), err)
+			slog.Error("cannot read file:",
+				"file", eventPath,
+				"error", err)
 			return
 		}
 
@@ -179,12 +198,17 @@ func (r *Runner) handleJobEvent(event notify.EventInfo) {
 		// still be included in the data structure.
 		var ansibleEvent map[string]interface{}
 		if err := json.Unmarshal(data, &ansibleEvent); err != nil {
-			log.Errorf("cannot unmarshal data: data=%v error=%v", data, err)
+			slog.Error("cannot unmarshal data:",
+				"data", data,
+				"error", err)
 			return
 		}
 
+		slog.Info("received job event")
 		// log the full event
-		log.Debugf("received job event: %v", prettyJson(data))
+		slog.Debug(
+			fmt.Sprintf("received job event: %s", prettyJson(data)),
+		)
 
 		eventData, ok := ansibleEvent["event_data"]
 		if !ok {
@@ -213,7 +237,7 @@ func (r *Runner) handleJobEvent(event notify.EventInfo) {
 
 		modifiedData, err := json.Marshal(ansibleEvent)
 		if err != nil {
-			log.Errorf("cannot marshal JSON: err=%v", err)
+			slog.Error("cannot marshal JSON:", "err", err)
 			return
 		}
 
@@ -221,13 +245,16 @@ func (r *Runner) handleJobEvent(event notify.EventInfo) {
 
 		if err != nil {
 			// problem filtering, return original event
-			log.Errorf("error filtering job event: err=%v", err)
-			log.Info("sending unfiltered job event...")
+			slog.Error("error filtering job event:", "err", err)
+			slog.Info("sending unfiltered job event...")
 			filteredModifiedData = modifiedData
 		}
 
 		r.Events <- filteredModifiedData
-		log.Debugf("event sent: event=%v", prettyJson(filteredModifiedData))
+		slog.Info("sent job event")
+		slog.Debug(
+			fmt.Sprintf("sent job event: %s", prettyJson(filteredModifiedData)),
+		)
 	}
 }
 
@@ -238,23 +265,23 @@ func (r *Runner) handleStatusFileEvent(event notify.EventInfo) {
 	//	and/or what happens when this function returns without closing the channels?
 	data, err := os.ReadFile(event.Path())
 	if err != nil {
-		log.Errorf("failed to read status file: err=%v", err)
+		slog.Error("failed to read status file:", "err", err)
 		return
 	}
 
 	status := string(data)
-	log.Infof("run complete: status=%v", status)
+	slog.Info("run complete:", "status", status)
 
 	if status == "failed" {
 		// publish an "executor_on_failed" event to signal
 		// cloud connector that a run has failed.
 		statusFailedError := errors.New("playbook run failed")
-		log.Error(statusFailedError)
+		slog.Error(statusFailedError.Error())
 		event := GenerateExecutorOnFailedEvent(r.ID, "UNDEFINED_ERROR", statusFailedError, uuid.New)
 
 		data, err := json.Marshal(event)
 		if err != nil {
-			log.Errorf("cannot marshal JSON: err=%v", err)
+			slog.Error("cannot marshal JSON:", "err", err)
 			return
 		}
 		r.Events <- json.RawMessage(data)
@@ -293,17 +320,23 @@ func (r *Runner) watch(
 	defer close(watchedEvents)
 
 	if err := notify.Watch(path, watchedEvents, events...); err != nil {
-		log.Errorf("cannot watch path for events: path=%v err=%v", path, err)
+		slog.Error("cannot watch path for events:",
+			"path", path,
+			"err", err,
+		)
 		return
 	}
 	defer notify.Stop(watchedEvents)
 
-	log.Tracef("start watching for events: path=%v events=%v", path, events)
-	defer log.Tracef("stop watching for events: path=%v", path)
+	slog.Info("start watching for events:",
+		"path", path,
+		"events", events,
+	)
+	defer slog.Info("stop watching for events:", "path", path)
 	for {
 		select {
 		case <-timeout:
-			log.Infof("timeout elapsed watching for events: path=%v", path)
+			slog.Info("timeout elapsed watching for events:", "path", path)
 			// since the status file handler is not invoked, clean up channels here, otherwise it will upload forever
 			r.end()
 			return
@@ -377,12 +410,12 @@ func filterJobEvent(jobEventData []byte) ([]byte, error) {
 func prettyJson(jsonBytes []byte) string {
 	var jsonObject map[string]any
 	if err := json.Unmarshal(jsonBytes, &jsonObject); err != nil {
-		log.Errorf("cannot unmarshal JSON: err=%v", err)
+		slog.Error("cannot unmarshal JSON:", "err", err)
 		return ""
 	}
 	pretty, err := json.MarshalIndent(jsonObject, "", "\t")
 	if err != nil {
-		log.Errorf("cannot marshal JSON: err=%v", err)
+		slog.Error("cannot marshal JSON:", "err", err)
 		return fmt.Sprintf("%v", jsonObject)
 	}
 	return string(pretty)

--- a/main.go
+++ b/main.go
@@ -5,12 +5,14 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
+
+	"log/slog"
 
 	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/constants"
 	"github.com/redhatinsights/yggdrasil/worker"
-	"github.com/subpop/go-log"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
 )
@@ -63,7 +65,10 @@ func main() {
 	app.Action = mainAction
 
 	if err := app.Run(os.Args); err != nil {
-		log.Fatal(err)
+		// previously called log.Fatal, equivalent to print and os.Exit(1)
+		// https://pkg.go.dev/log#Fatal
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }
 
@@ -83,11 +88,11 @@ func beforeAction(ctx *cli.Context) error {
 
 func mainAction(ctx *cli.Context) error {
 	loadConfigFromContext(ctx)
-	level, err := log.ParseLevel(config.DefaultConfig.LogLevel)
+	level, err := parseLevel(config.DefaultConfig.LogLevel)
 	if err != nil {
-		return cli.Exit(fmt.Errorf("cannot unmarshal log-level: %w", err), 1)
+		return cli.Exit(err, 1)
 	}
-	log.SetLevel(level)
+	slog.SetLogLoggerLevel(level)
 
 	w, err := worker.NewWorker(config.DefaultConfig.Directive, true, nil, nil, rx, nil)
 	if err != nil {
@@ -114,4 +119,27 @@ func loadConfigFromContext(ctx *cli.Context) {
 	config.DefaultConfig.VerifyPlaybook = ctx.Bool(config.FlagNameVerifyPlaybook)
 	config.DefaultConfig.ResponseInterval = ctx.Duration(config.FlagNameResponseInterval)
 	config.DefaultConfig.BatchEvents = ctx.Int(config.FlagNameBatchEvents)
+}
+
+// parseLevel parses the log level string from the config to an slog.Level
+func parseLevel(str string) (slog.Level, error) {
+	LevelUnknown := slog.Level(-99)
+
+	switch strings.ToUpper(str) {
+	case "ERROR":
+		return slog.LevelError, nil
+	case "WARN":
+		return slog.LevelWarn, nil
+	case "INFO":
+		return slog.LevelInfo, nil
+	case "DEBUG":
+		return slog.LevelDebug, nil
+	case "TRACE":
+		// slog has no "trace" level by default, use LevelDebug
+		// We've migrated all prior "trace" level log calls to other levels,
+		// but trace should still be a valid config option.
+		return slog.LevelDebug, nil
+	}
+
+	return LevelUnknown, fmt.Errorf("cannot parse log level: %v", str)
 }

--- a/worker.go
+++ b/worker.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime/multipart"
 	"net/textproto"
 	"strings"
@@ -18,7 +19,6 @@ import (
 	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/exec"
 	"github.com/redhatinsights/yggdrasil/worker"
-	"github.com/subpop/go-log"
 )
 
 type EventManager struct {
@@ -55,7 +55,7 @@ func rx(
 	metadata map[string]string,
 	data []byte,
 ) error {
-	log.Infof("message received: message-id=%v", id)
+	slog.Info("message received:", "message-id", id)
 
 	// Get returnURL from message metadata
 	returnURL, has := metadata["return_url"]
@@ -73,7 +73,7 @@ func rx(
 	// value loaded from the configuration file.
 	responseIntervalString, has := metadata["response_interval"]
 	if !has {
-		log.Warn("metadata missing response_interval, defaulting to 300")
+		slog.Warn("metadata missing response_interval, defaulting to 300")
 		responseIntervalString = "300"
 	}
 	responseInterval, err := time.ParseDuration(responseIntervalString + "s")
@@ -175,10 +175,11 @@ func (e *EventManager) processEvents(runner *ansible.Runner) {
 
 	// Transmit one final batch of all events.
 	if err := e.transmitEvents(e.cachedEvents); err != nil {
-		log.Errorf("cannot transmit events: err=%v", err)
+		slog.Error("cannot transmit events:", "err", err)
 	}
 
-	log.Infof("message finished: message-id=%v", e.id)
+	slog.Info("message finished:", "message-id", e.id)
+
 }
 
 // transmitCachedEvents periodically transmits a batch of cached events when the
@@ -218,13 +219,13 @@ func (e *EventManager) transmitCachedEvents() {
 
 			cachedEvents := append([]json.RawMessage{}, e.cachedEvents[batchStart:batchEnd]...)
 			e.cachedEventsLock.RUnlock()
-			log.Debugf(
-				"transmitting cached events: batchStart=%v batchEnd=%v",
-				batchStart,
-				batchEnd,
+			slog.Info(
+				"transmitting cached events:",
+				"batchStart", batchStart,
+				"batchEnd", batchEnd,
 			)
 			if err := e.transmitEvents(cachedEvents); err != nil {
-				log.Errorf("cannot transmit events: err=%v", err)
+				slog.Error("cannot transmit events:", "err", err)
 				continue
 			}
 
@@ -266,12 +267,12 @@ func (e *EventManager) transmitEvents(events []json.RawMessage) error {
 	if err != nil {
 		return fmt.Errorf("cannot transmit data: err=%v", err)
 	}
-	log.Debugf(
-		"received response: code=%v responseMetadata=%v",
-		responseCode,
-		responseMetadata,
+	slog.Info(
+		"received response:",
+		"responseCode", responseCode,
+		"responseMetadata", responseMetadata,
+		"responseBody", string(responseBody),
 	)
-	log.Tracef("responseBody=%v", string(responseBody))
 
 	if responseCode >= 400 {
 		// return an error if HTTP status code is 400 and up
@@ -291,13 +292,18 @@ func (e *EventManager) transmitEvents(events []json.RawMessage) error {
 // standard input. If the playbook passes verification, the playbook, stripped
 // of "insights_signature" variables is returned.
 func verifyPlaybook(data []byte) ([]byte, error) {
-	env := []string{
-		"PATH=/sbin:/bin:/usr/sbin:/usr/bin",
-	}
+	slog.Info("verifying playbook")
 
+	env := []string{"PATH=/sbin:/bin:/usr/sbin:/usr/bin"}
 	args := []string{"--stdin"}
-
 	stdin := bytes.NewReader(data)
+
+	slog.Info("launching rhc-playbook-verifier subprocess")
+	slog.Debug("launching with parameters:",
+		"args", args,
+		"env", env,
+		"stdin", string(data))
+
 	stdout, stderr, code, err := exec.RunProcess(
 		"/usr/libexec/rhc-playbook-verifier",
 		args,
@@ -315,7 +321,7 @@ func verifyPlaybook(data []byte) ([]byte, error) {
 	}
 
 	// verification succeeds, log here
-	log.Info("Playbook verified.")
+	slog.Info("playbook verified")
 
 	// Register a custom unmarshaler to support the YAML 1.1 boolean types
 	// "yes/no" and "on/off".
@@ -369,7 +375,7 @@ func buildRequestBody(body string, filename string) (*bytes.Buffer, string, erro
 	defer func() {
 		closeErr := writer.Close()
 		if closeErr != nil {
-			log.Errorf("cannot close request body writer: %v", closeErr)
+			slog.Error("cannot close request body writer:", "err", closeErr)
 		}
 	}()
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -5,8 +5,9 @@ import (
 	"os/exec"
 	"testing"
 
+	"log/slog"
+
 	"github.com/google/go-cmp/cmp"
-	"github.com/subpop/go-log"
 )
 
 func readFile(t *testing.T, file string) []byte {
@@ -51,7 +52,7 @@ func TestVerifyPlaybook(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			log.SetLevel(log.LevelDebug)
+			slog.SetLogLoggerLevel(slog.LevelDebug)
 			got, err := verifyPlaybook(test.input.playbook)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
This PR addresses the deprecated `go-log` package and replaces its calls with `slog`.

A few key points and differences to note:

- The `go-log` calls made extensive use of functions with `fmt.Sprintf`-like parameters. This is not available in `slog`, and instead you must provide key-value pairs as alternating arguments. This migration was easily done for the most part, since the prior logging already followed the output style that `slog` generates. In some cases, `fmt.Sprintf` was used instead where the key-value syntax was inconvenient (such as logging prettified JSON strings)

- `slog` does not include `Fatal` or `Trace` logging levels or functions. `Fatal` was replaced here by an equivalent "log-and-exit" approach. `Trace` was scarcely used in our case, and in my opinion, the events at the `trace` level should have been at a different level anyway. To maintain compatibility with configuration files on upgrade, `trace` is allowed as a configurable level, but will translate to `debug`.

- Some additional log messages were added, such as those indicating process state (file writes, subprocess calls)

- Some log messages had their log levels changed to improve log comprehension at different levels.

- `go-log` still remains as an "indirect" dependency since `yggdrasil` has not yet replaced it.