### PR TITLE
feat(RHINENG-19962): prevent two playbooks from running simultaneously

### DIFF
--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -193,6 +193,18 @@ def verify_playbook_failure_upload_failed(timeout=30):
         time.sleep(5)
     return False
 
+def verify_cant_run_two_playbooks(timeout=30):
+    """
+    This method returns True if the failure of playbook verification
+    is logged as an error, else False
+    """
+    start_time = time.time()
+    while (time.time() - start_time) < timeout:
+        if _is_in_journald_grep("a playbook run is already in progress"):
+            return True
+        time.sleep(5)
+    return False
+
 
 def _is_in_journald_grep(search_string):
     """

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -26,6 +26,10 @@ var (
 
 	// CacheDir is a path to a location where cache data can be stored.
 	CacheDir string
+
+	// PlaybookInProgressMarker is a path to a marker file that is created to communicate a playbook execution in progress,
+	// and deleted when a playbook is no longer in progress.
+	PlaybookInProgressMarker string
 )
 
 func init() {
@@ -60,4 +64,6 @@ func init() {
 	if CacheDir == "" {
 		CacheDir = filepath.Join(LocalStateDir, "cache", "rhc-worker-playbook")
 	}
+
+	PlaybookInProgressMarker = filepath.Join(StateDir, ".playbook-in-progress")
 }

--- a/main.go
+++ b/main.go
@@ -89,6 +89,15 @@ func mainAction(ctx *cli.Context) error {
 	}
 	log.SetLevel(level)
 
+	// delete any cached .playbook-in-progress file from unexpected exit
+	if err := os.Remove(constants.PlaybookInProgressMarker); err != nil {
+		log.Infof(
+			"cannot delete the .playbook-in-progress file: path=%v err=%v",
+			constants.PlaybookInProgressMarker,
+			err,
+		)
+	}
+
 	w, err := worker.NewWorker(config.DefaultConfig.Directive, true, nil, nil, rx, nil)
 	if err != nil {
 		return cli.Exit(fmt.Errorf("cannot create worker: %w", err), 1)


### PR DESCRIPTION
### What 
Prevent running two playbooks at once by utilizing a marker file at `/var/lib/rhc-worker-playbook/.playbook-in-progress`.

Also a bit of refactoring/DRY on communicating early failures back to Remediations.

### Why
Instances of `rhc-worker-playbook` "runs" are contained within a custom `rx` function that is passed to a yggdrasil `Worker`. 

- [`rx` definition](https://github.com/RedHatInsights/rhc-worker-playbook/blob/4f1c418b4f960672d712f0c4b0b857faceb9eec2/worker.go#L50)
- [worker instantiation](https://github.com/RedHatInsights/rhc-worker-playbook/blob/4f1c418b4f960672d712f0c4b0b857faceb9eec2/main.go#L92)

The `rx` function is called from a goroutine created in the worker's `com.redhat.Yggdrasil1.Worker1.Dispatch` method. Each playbook run then, is contained within its own goroutine.

- [`yggdrasil/worker` `rx` function call](https://github.com/RedHatInsights/yggdrasil/blob/54d5bac227d15331135f7d6caa5305fd8ae3c56f/worker/worker.go#L286)

Within the limitations of this project, we only control the contents of the `rx` function. We do not control the worker code outside the instantiation of the goroutine. To share state between two or more runs, without modifying the `yggdrasil` project and/or its worker API, we can use this marker file.

### How

This file is proactively deleted at the beginning of the `rhc-worker-playbook` process to prevent any cached residue from previous unexpected exits.

When a playbook run request is received, the existence of the file is checked.

If it does not exist, it is created, and the playbook run proceeds.

If it _does_ exist, the execution is canceled and an error is returned to both `yggdrasil` and Remediations.

Once the playbook run completes, the file is deleted to re-allow playbook run requests.