### PR TITLE
feat(RHINENG-24449): add http client

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -138,6 +138,11 @@ def rhc_worker_playbook_config_for_worker_test(enable_verify_playbook):
     config = toml.load(config_path)
     config["verify-playbook"] = enable_verify_playbook
     config["log-level"] = "trace"
+    
+    config["data-host"] = "localhost:8000"
+    config["cert-file"] = ""
+    config["key-file"] = ""    
+    
     with open(config_path, "w") as configfile:
         toml.dump(config, configfile)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,10 @@
 package config
 
-import "time"
+import (
+	"time"
+
+	"github.com/redhatinsights/rhc-worker-playbook/internal/constants"
+)
 
 const (
 	FlagNameDirective        = "directive"
@@ -8,6 +12,12 @@ const (
 	FlagNameVerifyPlaybook   = "verify-playbook"
 	FlagNameResponseInterval = "response-interval"
 	FlagNameBatchEvents      = "batch-events"
+	FlagNameCertFile         = "cert-file"
+	FlagNameKeyFile          = "key-file"
+	FlagNameCaRoot           = "ca-root"
+	FlagNameDataHost         = "data-host"
+	FlagNameHTTPRetries      = "http-retries"
+	FlagNameHTTPTimeout      = "http-timeout"
 )
 
 type Config struct {
@@ -28,6 +38,30 @@ type Config struct {
 	// BatchEvents is the number of events to batch together in a given transmit
 	// response.
 	BatchEvents int
+
+	// CertFile is a path to a public certificate, optionally used along with
+	// KeyFile to authenticate connections.
+	CertFile string
+
+	// KeyFile is a path to a private certificate, optionally used along with
+	// CertFile to authenticate connections.
+	KeyFile string
+
+	// CARoot is the list of paths with chain certificate file to optionally
+	// include in the TLS configration's CA root list.
+	CARoot []string
+
+	// DataHost is a hostname value to interject into all HTTP requests when
+	// handling data retrieval.
+	DataHost string
+
+	// HTTPRetries is the number of times the client will attempt to resend
+	// failed HTTP requests before giving up.
+	HTTPRetries int
+
+	// HTTPTimeout is the duration the client will wait before cancelling an
+	// HTTP request.
+	HTTPTimeout time.Duration
 }
 
 // DefaultConfig is a globally accessible Config data structure, initialized
@@ -38,4 +72,10 @@ var DefaultConfig = Config{
 	VerifyPlaybook:   true,
 	ResponseInterval: 0,
 	BatchEvents:      0,
+	CertFile:         "/etc/pki/consumer/cert.pem",
+	KeyFile:          "/etc/pki/consumer/key.pem",
+	CARoot:           []string{},
+	DataHost:         constants.DefaultDataHost,
+	HTTPRetries:      0,
+	HTTPTimeout:      0,
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -26,6 +26,10 @@ var (
 
 	// CacheDir is a path to a location where cache data can be stored.
 	CacheDir string
+
+	// DefaultDataHost is the default value used to force sending all HTTP
+	// traffic to a specific host.
+	DefaultDataHost string
 )
 
 func init() {
@@ -59,5 +63,9 @@ func init() {
 
 	if CacheDir == "" {
 		CacheDir = filepath.Join(LocalStateDir, "cache", "rhc-worker-playbook")
+	}
+
+	if DefaultDataHost == "" {
+		DefaultDataHost = "cert.cloud.redhat.com"
 	}
 }

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -1,0 +1,173 @@
+// Based on yggdrasil's http client
+// https://github.com/RedHatInsights/yggdrasil/blob/main/internal/http/client.go
+// https://github.com/RedHatInsights/yggdrasil/blob/main/internal/work/dispatcher.go
+
+package http
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
+	"github.com/subpop/go-log"
+)
+
+// Client is a specialized HTTP client, configured with mutual TLS certificate
+// authentication.
+type Client struct {
+	http.Client
+	userAgent string
+
+	// Retries is the number of times the client will attempt to resend failed
+	// HTTP requests before giving up.
+	Retries int
+}
+
+// NewHTTPClient creates a client with the given TLS configuration and
+// user-agent string.
+func NewHTTPClient(config *tls.Config, ua string) *Client {
+	client := http.Client{
+		Transport: http.DefaultTransport.(*http.Transport).Clone(),
+	}
+	client.Transport.(*http.Transport).TLSClientConfig = config.Clone()
+
+	return &Client{
+		Client:    client,
+		userAgent: ua,
+		Retries:   0,
+	}
+}
+
+func (c *Client) Get(url string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create HTTP request: %w", err)
+	}
+	req.Header.Add("User-Agent", c.userAgent)
+
+	log.Debugf("sending HTTP request: %v %v", req.Method, req.URL)
+	log.Tracef("request: %v", req)
+
+	return c.Do(req)
+}
+
+func (c *Client) Post(url string, headers map[string]string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("cannot create HTTP request: %w", err)
+	}
+
+	for k, v := range headers {
+		req.Header.Add(k, strings.TrimSpace(v))
+	}
+	req.Header.Add("User-Agent", c.userAgent)
+
+	log.Debugf("sending HTTP request: %v %v", req.Method, req.URL)
+	log.Tracef("request: %v", req)
+
+	return c.Do(req)
+}
+
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	var resp *http.Response
+	var err error
+	var attempt int
+
+	for {
+		if attempt > c.Retries {
+			return nil, fmt.Errorf("cannot do HTTP request: too many retries")
+		}
+		resp, err = c.Client.Do(req)
+		if err != nil {
+			if err.(*url.Error).Timeout() {
+				attempt++
+				continue
+			}
+			return nil, fmt.Errorf("cannot do HTTP request: %v", err)
+		}
+
+		switch resp.StatusCode {
+		case http.StatusServiceUnavailable, http.StatusTooManyRequests:
+			value := resp.Header.Get("Retry-After")
+			if value != "" {
+				var when time.Time
+				var err error
+
+				when, err = time.Parse(time.RFC1123, value)
+				if err != nil {
+					d, err := time.ParseDuration(value + "s")
+					if err != nil {
+						return nil, fmt.Errorf("cannot parse Retry-After header: %v", err)
+					}
+					when = time.Now().Add(d)
+				}
+				time.Sleep(time.Until(when))
+				attempt++
+				continue
+			}
+		}
+
+		log.Debugf("received HTTP response: %v", resp)
+
+		return resp, nil
+	}
+}
+
+// GetPlaybook wraps Client.Get and parses the response to a bytestring
+func (c *Client) GetPlaybook(addr string) (content []byte, err error) {
+	response, err := c.Get(addr)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get detached message content: %v", err)
+	}
+	content, err = io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read response body: %v", err)
+	}
+	if err = response.Body.Close(); err != nil {
+		return nil, fmt.Errorf("cannot close response body: %v", err)
+	}
+	return content, nil
+}
+
+// PostResults wraps Client.Post and parses the response to useful variables
+func (c *Client) PostResults(
+	addr string,
+	headers map[string]string,
+	body []byte,
+) (responseCode int, responseMetadata map[string]string, responseData []byte, err error) {
+	URL, err := url.Parse(addr)
+	if err != nil {
+		return -1, nil, nil, fmt.Errorf("cannot parse addr as URL: %v", err)
+	}
+	if URL.Scheme == "" {
+		return -1, nil, nil, fmt.Errorf("URL: '%v' has no scheme", addr)
+	}
+	if config.DefaultConfig.DataHost != "" {
+		URL.Host = config.DefaultConfig.DataHost
+	}
+	resp, err := c.Post(URL.String(), headers, body)
+	if err != nil {
+		return -1, nil, nil, fmt.Errorf("cannot perform HTTP request: %v", err)
+	}
+	responseData, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return -1, nil, nil, fmt.Errorf("cannot read HTTP response body: %v", err)
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return -1, nil, nil, fmt.Errorf("cannot close HTTP response body: %v", err)
+	}
+	responseCode = resp.StatusCode
+	responseMetadata = make(map[string]string)
+	for header := range resp.Header {
+		responseMetadata[header] = resp.Header.Get(header)
+	}
+
+	return responseCode, responseMetadata, responseData, nil
+}

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -1,0 +1,328 @@
+// Generated with Cursor
+package http
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
+)
+
+func TestNewHTTPClient(t *testing.T) {
+	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS13}
+	ua := "test-agent/1.0"
+	c := NewHTTPClient(tlsCfg, ua)
+
+	if c.userAgent != ua {
+		t.Fatalf("userAgent: got %q want %q", c.userAgent, ua)
+	}
+	if c.Retries != 0 {
+		t.Fatalf("Retries: got %d want 0", c.Retries)
+	}
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport type: got %T", c.Transport)
+	}
+	if tr.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig is nil")
+	}
+	if tr.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("TLS MinVersion: got %v want TLS 1.3", tr.TLSClientConfig.MinVersion)
+	}
+}
+
+func TestClient_Get(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %s want GET", r.Method)
+		}
+		if got := r.Header.Get("User-Agent"); got != "ua-test" {
+			t.Errorf("User-Agent: got %q want ua-test", got)
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewHTTPClient(&tls.Config{}, "ua-test")
+	resp, err := c.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Fatalf("body: got %q", body)
+	}
+	if err = resp.Body.Close(); err != nil {
+		t.Fatalf("failed to close response body err=%v", err)
+	}
+}
+
+func TestClient_Post(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method: got %s want POST", r.Method)
+		}
+		if got := r.Header.Get("User-Agent"); got != "ua-post" {
+			t.Errorf("User-Agent: got %q", got)
+		}
+		if got := r.Header.Get("X-Custom"); got != "trimmed" {
+			t.Errorf("X-Custom after trim: got %q want trimmed", got)
+		}
+		b, _ := io.ReadAll(r.Body)
+		if string(b) != "payload" {
+			t.Errorf("body: got %q", b)
+		}
+		_, _ = w.Write([]byte("done"))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewHTTPClient(&tls.Config{}, "ua-post")
+	resp, err := c.Post(srv.URL, map[string]string{"X-Custom": "  trimmed  "}, []byte("payload"))
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	if err = resp.Body.Close(); err != nil {
+		t.Fatalf("failed to close response body err=%v", err)
+	}
+}
+
+func TestClient_Do_retries_on_timeout(t *testing.T) {
+	var calls int
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return nil, &url.Error{Op: "Get", URL: req.URL.String(), Err: context.DeadlineExceeded}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	c := NewHTTPClient(&tls.Config{}, "ua")
+	c.Transport = rt
+	c.Retries = 1
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.test/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	if calls != 2 {
+		t.Fatalf("round trips: got %d want 2", calls)
+	}
+
+	if err = resp.Body.Close(); err != nil {
+		t.Fatalf("failed to close response body err=%v", err)
+	}
+}
+
+func TestClient_Do_too_many_retries_after_503(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewHTTPClient(&tls.Config{}, "ua")
+	c.Retries = 0
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.Do(req)
+	if err == nil || !strings.Contains(err.Error(), "too many retries") {
+		t.Fatalf("expected too many retries error, got %v", err)
+	}
+}
+
+func TestClient_Do_retry_after_503_then_success(t *testing.T) {
+	var n int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		if n == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewHTTPClient(&tls.Config{}, "ua")
+	c.Retries = 2
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	if n != 2 {
+		t.Fatalf("handler calls: got %d want 2", n)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+
+	if err = resp.Body.Close(); err != nil {
+		t.Fatalf("failed to close response body err=%v", err)
+	}
+}
+
+func TestClient_Do_invalid_retry_after(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "not-a-duration")
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewHTTPClient(&tls.Config{}, "ua")
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.Do(req)
+	if err == nil || !strings.Contains(err.Error(), "cannot parse Retry-After") {
+		t.Fatalf("expected Retry-After parse error, got %v", err)
+	}
+}
+
+func TestClient_GetPlaybook(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("playbook-yaml"))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewHTTPClient(&tls.Config{}, "ua")
+	got, err := c.GetPlaybook(srv.URL)
+	if err != nil {
+		t.Fatalf("GetPlaybook: %v", err)
+	}
+	if string(got) != "playbook-yaml" {
+		t.Fatalf("content: got %q", got)
+	}
+}
+
+func TestClient_PostResults_invalid_url(t *testing.T) {
+	c := NewHTTPClient(&tls.Config{}, "ua")
+	_, _, _, err := c.PostResults("://bad", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for bad URL")
+	}
+}
+
+func TestClient_PostResults_missing_scheme(t *testing.T) {
+	c := NewHTTPClient(&tls.Config{}, "ua")
+	_, _, _, err := c.PostResults("example.com/path", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "no scheme") {
+		t.Fatalf("expected no scheme error, got %v", err)
+	}
+}
+
+func TestClient_PostResults_success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Reply", "1")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	orig := config.DefaultConfig
+	t.Cleanup(func() { config.DefaultConfig = orig })
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.DefaultConfig.DataHost = ""
+
+	c := NewHTTPClient(&tls.Config{}, "ua")
+	code, meta, body, err := c.PostResults(srv.URL, map[string]string{"X-Req": "a"}, []byte("{}"))
+	if err != nil {
+		t.Fatalf("PostResults: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("code: got %d", code)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("body: got %s", body)
+	}
+	if meta["X-Reply"] != "1" {
+		t.Fatalf("metadata X-Reply: got %#v", meta)
+	}
+	if u.Host == "" {
+		t.Fatal("parsed URL host empty")
+	}
+}
+
+func TestClient_PostResults_data_host_override(t *testing.T) {
+	var seenHost string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenHost = r.Host
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(srv.Close)
+
+	orig := config.DefaultConfig
+	t.Cleanup(func() { config.DefaultConfig = orig })
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.DefaultConfig.DataHost = u.Host
+
+	c := NewHTTPClient(&tls.Config{}, "ua")
+	// URL host is different from DataHost target — PostResults forces DataHost.
+	code, _, _, err := c.PostResults("http://other.example.com/submit", nil, []byte("{}"))
+	if err != nil {
+		t.Fatalf("PostResults: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("code: got %d", code)
+	}
+	if seenHost != u.Host {
+		t.Fatalf("request Host: got %q want %q (DataHost override)", seenHost, u.Host)
+	}
+}
+
+func TestClient_PostResults_response_metadata(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("A", "1")
+		w.Header().Set("B", "2")
+	}))
+	t.Cleanup(srv.Close)
+
+	orig := config.DefaultConfig
+	t.Cleanup(func() { config.DefaultConfig = orig })
+	config.DefaultConfig.DataHost = ""
+
+	c := NewHTTPClient(&tls.Config{}, "ua")
+	_, meta, _, err := c.PostResults(srv.URL, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta["A"] != "1" || meta["B"] != "2" {
+		t.Fatalf("metadata A/B: got %#v", meta)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/http/tls.go
+++ b/internal/http/tls.go
@@ -1,0 +1,77 @@
+// Based on yggdrasil's TLS config
+// https://github.com/RedHatInsights/yggdrasil/tree/main/internal/config
+
+package http
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
+)
+
+func newTLSConfig(
+	certPEMBlock []byte,
+	keyPEMBlock []byte,
+	CARootPEMBlocks [][]byte,
+) (*tls.Config, error) {
+	config := &tls.Config{
+		MinVersion: tls.VersionTLS13,
+	}
+
+	if len(certPEMBlock) > 0 && len(keyPEMBlock) > 0 {
+		cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse x509 key pair: %w", err)
+		}
+
+		config.Certificates = []tls.Certificate{cert}
+	}
+
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("cannot copy system certificate pool: %w", err)
+	}
+	for _, data := range CARootPEMBlocks {
+		pool.AppendCertsFromPEM(data)
+	}
+	config.RootCAs = pool
+
+	return config, nil
+}
+
+// CreateTLSConfig creates a tls.Config object from the current configuration.
+func CreateTLSConfig(conf config.Config) (*tls.Config, error) {
+	var certData, keyData []byte
+	var err error
+	rootCAs := make([][]byte, 0)
+
+	if conf.CertFile != "" && conf.KeyFile != "" {
+		certData, err = os.ReadFile(conf.CertFile)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read cert-file '%v': %w", conf.CertFile, err)
+		}
+
+		keyData, err = os.ReadFile(conf.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read key-file '%v': %w", conf.KeyFile, err)
+		}
+	}
+
+	for _, file := range conf.CARoot {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read ca-file '%v': %w", file, err)
+		}
+		rootCAs = append(rootCAs, data)
+	}
+
+	tlsConfig, err := newTLSConfig(certData, keyData, rootCAs)
+	if err != nil {
+		return nil, err
+	}
+
+	return tlsConfig, nil
+}

--- a/internal/http/tls_test.go
+++ b/internal/http/tls_test.go
@@ -1,0 +1,171 @@
+// Generated with Cursor
+package http
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
+)
+
+func TestNewTLSConfig_empty(t *testing.T) {
+	cfg, err := newTLSConfig(nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newTLSConfig: %v", err)
+	}
+	if cfg.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("MinVersion: got %v", cfg.MinVersion)
+	}
+	if cfg.RootCAs == nil {
+		t.Fatal("RootCAs is nil")
+	}
+	if len(cfg.Certificates) != 0 {
+		t.Fatalf("expected no client certificates, got %d", len(cfg.Certificates))
+	}
+}
+
+func TestNewTLSConfig_with_client_cert(t *testing.T) {
+	certPEM, keyPEM := mustCertKeyPair(t)
+	cfg, err := newTLSConfig(certPEM, keyPEM, nil)
+	if err != nil {
+		t.Fatalf("newTLSConfig: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("Certificates: got %d want 1", len(cfg.Certificates))
+	}
+}
+
+func TestNewTLSConfig_invalid_key_pair(t *testing.T) {
+	_, err := newTLSConfig([]byte("not pem"), []byte("not pem"), nil)
+	if err == nil || !strings.Contains(err.Error(), "cannot parse x509 key pair") {
+		t.Fatalf("expected x509 key pair error, got %v", err)
+	}
+}
+
+func TestNewTLSConfig_extra_ca_pem(t *testing.T) {
+	ca := mustPEMCA(t)
+	cfg, err := newTLSConfig(nil, nil, [][]byte{ca})
+	if err != nil {
+		t.Fatalf("newTLSConfig: %v", err)
+	}
+	if cfg.RootCAs == nil {
+		t.Fatal("RootCAs is nil")
+	}
+}
+
+func TestCreateTLSConfig_missing_files(t *testing.T) {
+	_, err := CreateTLSConfig(config.Config{
+		CertFile: "/nonexistent/cert.pem",
+		KeyFile:  "/nonexistent/key.pem",
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot read cert-file") {
+		t.Fatalf("expected cert read error, got %v", err)
+	}
+}
+
+func TestCreateTLSConfig_missing_ca(t *testing.T) {
+	_, err := CreateTLSConfig(config.Config{
+		CARoot: []string{"/nonexistent/ca.pem"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot read ca-file") {
+		t.Fatalf("expected ca read error, got %v", err)
+	}
+}
+
+func TestCreateTLSConfig_from_files(t *testing.T) {
+	dir := t.TempDir()
+	certPEM, keyPEM := mustCertKeyPair(t)
+	caPEM := mustPEMCA(t)
+
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	caPath := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, caPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := CreateTLSConfig(config.Config{
+		CertFile: certPath,
+		KeyFile:  keyPath,
+		CARoot:   []string{caPath},
+	})
+	if err != nil {
+		t.Fatalf("CreateTLSConfig: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("Certificates: got %d", len(cfg.Certificates))
+	}
+}
+
+func mustCertKeyPair(t *testing.T) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial := big.NewInt(1)
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{Organization: []string{"test"}},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var certBuf bytes.Buffer
+	_ = pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var keyBuf bytes.Buffer
+	_ = pem.Encode(&keyBuf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return certBuf.Bytes(), keyBuf.Bytes()
+}
+
+func mustPEMCA(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{Organization: []string{"test-ca"}},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	_ = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return buf.Bytes()
+}

--- a/main.go
+++ b/main.go
@@ -32,29 +32,51 @@ func main() {
 		},
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:  config.FlagNameDirective,
-			Value: config.DefaultConfig.Directive,
 			Usage: "set directive to `DIRECTIVE`",
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:  config.FlagNameLogLevel,
-			Value: config.DefaultConfig.LogLevel,
 			Usage: "set log level to `LEVEL`",
 		}),
 		altsrc.NewBoolFlag(&cli.BoolFlag{
 			Name:  config.FlagNameVerifyPlaybook,
-			Value: config.DefaultConfig.VerifyPlaybook,
 			Usage: "use GPG signature verification before executing a playbook",
 		}),
 		altsrc.NewDurationFlag(&cli.DurationFlag{
 			Name:   config.FlagNameResponseInterval,
-			Value:  config.DefaultConfig.ResponseInterval,
 			Usage:  "override per-message response interval value",
 			Hidden: true,
 		}),
 		altsrc.NewIntFlag(&cli.IntFlag{
 			Name:   config.FlagNameBatchEvents,
-			Value:  config.DefaultConfig.BatchEvents,
 			Usage:  "number of events to batch together in a single transmision",
+			Hidden: true,
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:  config.FlagNameCertFile,
+			Usage: "Use `FILE` as the client certificate",
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:  config.FlagNameKeyFile,
+			Usage: "Use `FILE` as the client's private key",
+		}),
+		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+			Name:   config.FlagNameCaRoot,
+			Hidden: true,
+			Usage:  "Use `FILE` as the root CA",
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:  config.FlagNameDataHost,
+			Usage: "Force all HTTP traffic over `HOST`",
+		}),
+		altsrc.NewIntFlag(&cli.IntFlag{
+			Name:   config.FlagNameHTTPRetries,
+			Usage:  "Retry HTTP requests `N` times",
+			Hidden: true,
+		}),
+		altsrc.NewDurationFlag(&cli.DurationFlag{
+			Name:   config.FlagNameHTTPTimeout,
+			Usage:  "Wait for `DURATION` before cancelling an HTTP request",
 			Hidden: true,
 		}),
 	}
@@ -114,4 +136,9 @@ func loadConfigFromContext(ctx *cli.Context) {
 	config.DefaultConfig.VerifyPlaybook = ctx.Bool(config.FlagNameVerifyPlaybook)
 	config.DefaultConfig.ResponseInterval = ctx.Duration(config.FlagNameResponseInterval)
 	config.DefaultConfig.BatchEvents = ctx.Int(config.FlagNameBatchEvents)
+	config.DefaultConfig.CertFile = ctx.String(config.FlagNameCertFile)
+	config.DefaultConfig.KeyFile = ctx.String(config.FlagNameKeyFile)
+	config.DefaultConfig.DataHost = ctx.String(config.FlagNameDataHost)
+	config.DefaultConfig.HTTPRetries = ctx.Int(config.FlagNameHTTPRetries)
+	config.DefaultConfig.HTTPTimeout = ctx.Duration(config.FlagNameHTTPTimeout)
 }

--- a/worker.go
+++ b/worker.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/textproto"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -16,7 +17,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/ansible"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
+	"github.com/redhatinsights/rhc-worker-playbook/internal/constants"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/exec"
+	"github.com/redhatinsights/rhc-worker-playbook/internal/http"
 	"github.com/redhatinsights/yggdrasil/worker"
 	"github.com/subpop/go-log"
 )
@@ -26,6 +29,7 @@ type EventManager struct {
 	returnURL         string
 	responseInterval  time.Duration
 	worker            *worker.Worker
+	httpClient        *http.Client
 	cachedEvents      []json.RawMessage
 	cachedEventsLock  sync.RWMutex
 	stopSendingEvents chan struct{}
@@ -36,6 +40,7 @@ func NewEventManager(
 	returnURL string,
 	responseInterval time.Duration,
 	worker *worker.Worker,
+	client *http.Client,
 ) *EventManager {
 	return &EventManager{
 		id:                id,
@@ -44,6 +49,7 @@ func NewEventManager(
 		worker:            worker,
 		cachedEvents:      []json.RawMessage{},
 		stopSendingEvents: make(chan struct{}),
+		httpClient:        client,
 	}
 }
 
@@ -56,6 +62,13 @@ func rx(
 	data []byte,
 ) error {
 	log.Infof("message received: message-id=%v", id)
+
+	// Initialize HTTP client
+	tlsConfig, err := http.CreateTLSConfig(config.DefaultConfig)
+	httpClient := http.NewHTTPClient(tlsConfig, "rhc-worker-playbook/"+constants.Version)
+	if err != nil {
+		return err
+	}
 
 	// Get returnURL from message metadata
 	returnURL, has := metadata["return_url"]
@@ -93,12 +106,21 @@ func rx(
 		responseInterval = 500 * time.Millisecond
 	}
 
+	urlString, err := parsePlaybookUrl(data)
+	if err != nil {
+		return err
+	}
+	playbook, err := httpClient.GetPlaybook(urlString)
+	if err != nil {
+		return err
+	}
+
 	// Create the event manager.
-	eventManager := NewEventManager(id, returnURL, responseInterval, w)
+	eventManager := NewEventManager(id, returnURL, responseInterval, w, httpClient)
 
 	// TODO [RHINENG-24450]: "data" is no longer the playbook, but a URL. it must be fetched first
 	if config.DefaultConfig.VerifyPlaybook {
-		d, err := verifyPlaybook(data)
+		verifiedPlaybook, err := verifyPlaybook(playbook)
 		if err != nil {
 			verifyPlaybookError := err
 
@@ -144,7 +166,7 @@ func rx(
 
 			return verifyPlaybookError
 		}
-		data = d
+		playbook = verifiedPlaybook
 	}
 
 	// Create the playbook runner.
@@ -155,7 +177,7 @@ func rx(
 	go eventManager.transmitCachedEvents()
 
 	// Run the playbook.
-	err = runner.Run(data)
+	err = runner.Run(playbook)
 	if err != nil {
 		return fmt.Errorf("cannot run playbook: err=%w", err)
 	}
@@ -255,16 +277,14 @@ func (e *EventManager) transmitEvents(events []json.RawMessage) error {
 		return fmt.Errorf("cannot build request body: err=%v", err)
 	}
 
-	// TODO [RHINENG-24450]: use internal HTTP client instead of transmitting back to yggdrasil
-	responseCode, responseMetadata, responseBody, err := e.worker.Transmit(
+	responseCode, responseMetadata, responseBody, err := e.httpClient.PostResults(
 		e.returnURL,
-		uuid.New().String(),
-		e.id,
 		map[string]string{
 			"Content-Type": outerContentType,
 		},
 		requestBody.Bytes(),
 	)
+
 	if err != nil {
 		return fmt.Errorf("cannot transmit data: err=%v", err)
 	}
@@ -397,4 +417,22 @@ func buildRequestBody(body string, filename string) (*bytes.Buffer, string, erro
 	outerContentType := fmt.Sprintf("multipart/form-data; boundary=%s", writer.Boundary())
 
 	return requestBody, outerContentType, nil
+}
+
+// parsePlaybookUrl parses the incoming bytestring as a URL, validates it, sets the data host, and returns a string
+func parsePlaybookUrl(data []byte) (string, error) {
+	var urlStr string
+	err := json.Unmarshal(data, &urlStr)
+	if err != nil {
+		return "", fmt.Errorf("unable to unmarshal JSON string fragment: %v", err)
+	}
+	// When string fragment was unmarshalled, then we can try to parse string as URL
+	URL, err := url.Parse(urlStr)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse content %v as URL: %v", urlStr, err)
+	}
+	if config.DefaultConfig.DataHost != "" {
+		URL.Host = config.DefaultConfig.DataHost
+	}
+	return URL.String(), nil
 }


### PR DESCRIPTION
This PR implements an HTTP client directly in `rhc-worker-playbook`, so that we can control HTTP messages without the use of `yggdrasil`'s client.

This is necessary because communication with `yggdrasil` is limited and we cannot customize HTTP parameters to a meaningful extent. Having our own client means that we can potentially prepare different request headers/urls/formats for different Ansible versioning strategies in the future.

See the [Ansible 12 porting guide](https://docs.ansible.com/projects/ansible/devel/porting_guides/porting_guide_12.html) for information on future Ansible changes.

This PR contains the following:
#### HTTP client implementation
In order to keep things as simple and consistent as possible, this code was copied almost entirely wholesale from `yggdrasil`. Their client is an internal package so it cannot be simply imported and used as-is. Thus, it has been copied over.  The TLS config code has also been copied.

The current `yggdrasil` HTTP client has no unit tests -- I've added some Cursor-generated tests for completeness.

Some additional configuration options have been added to support it (continued next).

#### Additional configuration options
To support the HTTP client, some additional configuration options must be added. These are all from `yggdrasil` and function the same.
- `cert-file` - location of the certificate file on the file system
- `key-file` - location of the key file on the file system
- `ca-root` - additional locations to specify for a CA root
- `data-host` - hostname from which remote content is to be downloaded -- the URL for a request will always have `data-host` substituted into it
- `http-retries` - number of times to retry a request
- `http-timeout` - timeout for a request

#### Other stuff
- The method `parsePlaybookUrl` gets the URL of a playbook out of the incoming message from `yggdrasil`.
- The convenience methods `GetPlaybook` and `PostResults` to abstract HTTP request validation and body parsing.