### PR TITLE
feat(RHINENG-26036): prevent two playbooks from running simultaneously

### DIFF
--- a/integration-tests/test_rhc_worker_playbook.py
+++ b/integration-tests/test_rhc_worker_playbook.py
@@ -15,6 +15,7 @@ from utils import (
     verify_playbook_verification_success_log,
     verify_uploaded_event_runner_data_is_filtered,
     verify_playbook_failure_upload_failed,
+    verify_cant_run_two_playbooks,
 )
 from conftest import FakeRequestHandlerPOSTFails
 
@@ -271,3 +272,47 @@ def test_playbook_verify_failure_invalid_signature_exclude(
 
     assert verify_playbook_verification_failure_log()
     assert verify_playbook_verification_failure_upload(http_server)
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize("enable_verify_playbook", [False])
+@pytest.mark.skipif(
+    pytest.rhel_major_version == "unknown" or int(pytest.rhel_major_version) < 10,
+    reason="This test is only supported on RHEL10 and above",
+)
+def test_no_two_playbooks_at_once(
+    http_server,
+    rhc_worker_playbook_config_for_worker_test,
+    yggdrasil_config_for_local_mqtt_broker,
+    restart_services,
+): 
+    """
+    test_stops:
+    1. Publish a message to MQTT to start a playbook run
+    2. While playbook is running, attempt to run another playbook
+    3. Verify the second playbook fails to initialize
+    """   
+    playbook_url = "http://localhost:8000/resources/pause1m.yml"
+
+    logger.info(f"Playbook will be downloaded from: {playbook_url}")
+    data_message = build_data_msg_for_worker_playbook(content=playbook_url)
+    topic = mqtt_data_topic()
+
+    logger.info(f"Publishing message to MQTT broker. Topic: {topic}")
+    publish_message(topic=topic, payload=json.dumps(data_message))
+
+    # wait a few seconds for the playbook run to begin
+    time.sleep(5)
+
+    # attempt to start another playbook, should fail
+    logger.info("Attempting to launch a simultaneous playbook run...")
+    logger.info(f"Publishing message to MQTT broker. Topic: {topic}")
+    data_message_2 = build_data_msg_for_worker_playbook(content=playbook_url)
+    publish_message(topic=topic, payload=json.dumps(data_message_2))
+    logger.info("Verifying that a simultaneous playbook run fails to start...")
+    assert verify_cant_run_two_playbooks()
+
+    # wait for the first one to finish
+    assert verify_playbook_execution_status(
+        data_message["metadata"]["crc_dispatcher_correlation_id"], timeout=90
+    )

--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -194,6 +194,19 @@ def verify_playbook_failure_upload_failed(timeout=30):
     return False
 
 
+def verify_cant_run_two_playbooks(timeout=30):
+    """
+    This method returns True if the failure of playbook verification
+    is logged as an error, else False
+    """
+    start_time = time.time()
+    while (time.time() - start_time) < timeout:
+        if _is_in_journald_grep("a playbook run is already in progress"):
+            return True
+        time.sleep(5)
+    return False
+
+
 def _is_in_journald_grep(search_string):
     """
     Check journald logs for rhc-worker-playbook for the presence of

--- a/worker.go
+++ b/worker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/goccy/go-yaml"
@@ -15,6 +16,8 @@ import (
 	"github.com/redhatinsights/yggdrasil/worker"
 	"github.com/subpop/go-log"
 )
+
+var playbookAlreadyRunning sync.Mutex
 
 func rx(
 	w *worker.Worker,
@@ -103,6 +106,28 @@ func rx(
 	if err := eventManager.SendExecutorOnStartEvent(); err != nil {
 		return err
 	}
+
+	// Try and lock the mutex.
+	// If the lock is successful, continue.
+	// If the lock is unsuccessful, a playbook is already running. Send an error to remediations and exit.
+	if !playbookAlreadyRunning.TryLock() {
+		// playbook is currently in progress
+		playbookAlreadyRunningErr := errors.New(
+			"a playbook run is already in progress, please wait until the current playbook finishes before executing another",
+		)
+
+		if err := eventManager.SendExecutorOnFailedEvent(
+			"ANSIBLE_PLAYBOOK_ALREADY_RUNNING",
+			playbookAlreadyRunningErr,
+		); err != nil {
+			return errors.Join(playbookAlreadyRunningErr, err)
+		}
+
+		return playbookAlreadyRunningErr
+	}
+
+	// Unlock the mutex after the playbook run
+	defer playbookAlreadyRunning.Unlock()
 
 	// Verify the playbook
 	if config.DefaultConfig.VerifyPlaybook {


### PR DESCRIPTION
Use a mutex to indicate that a playbook is already in progress, and cancel any additional playbook run requests while the mutex is locked.