### PR TITLE
refactor(RHINENG-21857): use slog for logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/redhatinsights/yggdrasil v0.4.9
 	github.com/rjeczalik/notify v0.9.3
-	github.com/subpop/go-log v0.1.2
 	github.com/urfave/cli/v2 v2.27.7
 )
 
@@ -17,6 +16,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/subpop/go-log v0.1.2 // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/redhatinsights/rhc-worker-playbook/internal/constants"
+	"github.com/redhatinsights/rhc-worker-playbook/internal/log"
 	"github.com/rjeczalik/notify"
-	"github.com/subpop/go-log"
 )
 
 // Runner maintains the state of a playbook run during execution.

--- a/internal/ansible/event_manager.go
+++ b/internal/ansible/event_manager.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
+	"github.com/redhatinsights/rhc-worker-playbook/internal/log"
 	"github.com/redhatinsights/yggdrasil/worker"
-	"github.com/subpop/go-log"
 )
 
 // createUuidFunc is a function that returns a UUID, typically uuid.New(),

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,125 @@
+package log
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+var LevelFatal slog.Level = slog.Level(12)
+var LevelTrace slog.Level = slog.Level(-8)
+var LevelUnknown slog.Level = slog.Level(-99)
+
+// custom handler so FATAL and TRACE level strings are represented in the log
+var logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+	ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+		if a.Key == slog.LevelKey {
+			level := a.Value.Any().(slog.Level)
+			switch level {
+			case LevelFatal:
+				a.Value = slog.StringValue("FATAL")
+			case LevelTrace:
+				a.Value = slog.StringValue("TRACE")
+			}
+		}
+		return a
+	},
+}))
+
+// ParseLevel parses the log level string to an slog.Level
+func ParseLevel(str string) (slog.Level, error) {
+	switch strings.ToUpper(str) {
+	case "ERROR":
+		return slog.LevelError, nil
+	case "WARN":
+		return slog.LevelWarn, nil
+	case "INFO":
+		return slog.LevelInfo, nil
+	case "DEBUG":
+		return slog.LevelDebug, nil
+	case "TRACE":
+		// slog has no trace level by default
+		return LevelTrace, nil
+	}
+
+	return LevelUnknown, fmt.Errorf("cannot parse log level: %v", str)
+}
+
+// SetLevel sets the log level from a provided slog.Level
+func SetLevel(level slog.Level) {
+	slog.SetDefault(logger)
+	slog.SetLogLoggerLevel(level)
+}
+
+// Debug wraps the slog.Debug method
+func Debug(msg string, args ...any) {
+	slog.Debug(msg, args...)
+}
+
+// Debugf wraps the slog.Debug method
+// and passes the arguments to fmt.Sprintf
+func Debugf(msg string, args ...any) {
+	slog.Debug(fmt.Sprintf(msg, args...))
+}
+
+// Error wraps the slog.Error method
+func Error(msg string, args ...any) {
+	slog.Error(msg, args...)
+}
+
+// Errorf wraps the slog.Error method
+// and passes the arguments to fmt.Sprintf
+func Errorf(msg string, args ...any) {
+	slog.Error(fmt.Sprintf(msg, args...))
+}
+
+// Fatal wraps the slog.Log method with a custom log level,
+// and mimics go's log.Fatal which calls os.Exit(1)
+// https://pkg.go.dev/log#Fatal
+func Fatal(msg string, args ...any) {
+	slog.Log(context.TODO(), LevelFatal, msg, args...)
+	os.Exit(1)
+}
+
+// Fatal wraps the slog.Log method with a custom log level,
+// passes the arguments to fmt.Sprintf,
+// and mimics go's log.Fatal which calls os.Exit(1)
+// https://pkg.go.dev/log#Fatal
+func Fatalf(msg string, args ...any) {
+	slog.Log(context.TODO(), LevelFatal, fmt.Sprintf(msg, args...))
+	os.Exit(1)
+}
+
+// Info wraps the slog.Info method
+func Info(msg string, args ...any) {
+	slog.Info(msg, args...)
+}
+
+// Infof wraps the slog.Info method
+// and passes the arguments to fmt.Sprintf
+func Infof(msg string, args ...any) {
+	slog.Info(fmt.Sprintf(msg, args...))
+}
+
+// Trace wraps the slog.Log method with a custom log level,
+func Trace(msg string, args ...any) {
+	slog.Log(context.TODO(), LevelTrace, msg, args...)
+}
+
+// Tracef wraps the slog.Log method with a custom log level
+// and passes the arguments to fmt.Sprintf
+func Tracef(msg string, args ...any) {
+	slog.Log(context.TODO(), LevelTrace, fmt.Sprintf(msg, args...))
+}
+
+// Warn wraps the slog.Warn method
+func Warn(msg string, args ...any) {
+	slog.Warn(msg, args...)
+}
+
+// Warnf wraps the slog.Warn method
+func Warnf(msg string, args ...any) {
+	slog.Warn(fmt.Sprintf(msg, args...))
+}

--- a/main.go
+++ b/main.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/constants"
+	"github.com/redhatinsights/rhc-worker-playbook/internal/log"
 	"github.com/redhatinsights/yggdrasil/worker"
-	"github.com/subpop/go-log"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
 )
@@ -63,7 +63,7 @@ func main() {
 	app.Action = mainAction
 
 	if err := app.Run(os.Args); err != nil {
-		log.Fatal(err)
+		log.Fatal(err.Error())
 	}
 }
 

--- a/worker.go
+++ b/worker.go
@@ -13,8 +13,8 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/ansible"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
+	"github.com/redhatinsights/rhc-worker-playbook/internal/log"
 	"github.com/redhatinsights/yggdrasil/worker"
-	"github.com/subpop/go-log"
 )
 
 var playbookAlreadyRunning sync.Mutex

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"log/slog"
 	"os"
 	"os/exec"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/subpop/go-log"
+	"github.com/redhatinsights/rhc-worker-playbook/internal/log"
 )
 
 func readFile(t *testing.T, file string) []byte {
@@ -51,7 +52,7 @@ func TestVerifyPlaybook(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			log.SetLevel(log.LevelDebug)
+			log.SetLevel(slog.LevelDebug)
 			got, err := verifyPlaybook(test.input.playbook)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
- Removes deprecated `go-log` dependency.
- Adds `log` module which initializes logging and wraps `slog` methods for minimal intrusion into existing code.

**TODO in a future commit:**
- use slog's convenience methods directly instead of manually `Sprintf`-ing `key=value` strings in our error messages
- logging messages should be lowercase per Go conventions