### PR TITLE
refactor(RHINENG-21857): use slog for logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/redhatinsights/yggdrasil v0.4.9
 	github.com/rjeczalik/notify v0.9.3
-	github.com/subpop/go-log v0.1.2
 	github.com/urfave/cli/v2 v2.27.7
 )
 
@@ -17,6 +16,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/subpop/go-log v0.1.2 // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/integration-tests/utils/__init__.py
+++ b/integration-tests/utils/__init__.py
@@ -124,7 +124,7 @@ def verify_playbook_verification_success_log(timeout=30):
     """
     start_time = time.time()
     while (time.time() - start_time) < timeout:
-        if _is_in_journald_grep("Playbook verified."):
+        if _is_in_journald_grep("playbook verified."):
             return True
         time.sleep(5)
     return False

--- a/internal/ansible/ansible.go
+++ b/internal/ansible/ansible.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/redhatinsights/rhc-worker-playbook/internal/constants"
 	"github.com/rjeczalik/notify"
-	"github.com/subpop/go-log"
 )
 
 // Runner maintains the state of a playbook run during execution.
@@ -59,12 +59,14 @@ func (r *Runner) Run(playbook []byte) error {
 	defer close(r.stopJobEventsWatch)
 
 	// write playbook to the filesystem
+	slog.Info("writing playbook to file:", "path", r.playbookPath)
 	if err := os.WriteFile(r.playbookPath, playbook, 0600); err != nil {
 		return fmt.Errorf("cannot write playbook file: path=%v err=%w", r.playbookPath, err)
 	}
 
 	// precreate the job_events directory so that we can watch for when events
 	// get written to it.
+	slog.Info("creating job_events directory:", "path", r.jobEventsPath)
 	if err := os.MkdirAll(r.jobEventsPath, 0750); err != nil {
 		return fmt.Errorf(
 			"cannot create job_events directory: directory=%v err=%w",
@@ -104,18 +106,26 @@ func (r *Runner) Run(playbook []byte) error {
 		),
 	}
 
+	slog.Info("launching python3 (ansible-runner) subprocess")
+	slog.Debug("launching with parameters:",
+		"args", ansibleRunnerCmd.Args,
+		"env", ansibleRunnerCmd.Env,
+	)
 	if err := ansibleRunnerCmd.Start(); err != nil {
 		return fmt.Errorf("cannot start ansible-runner: err=%w", err)
 	}
 
-	log.Infof("run started: pid=%v", ansibleRunnerCmd.Process.Pid)
+	slog.Info("run started:", "pid", ansibleRunnerCmd.Process.Pid)
 
 	if err := ansibleRunnerCmd.Wait(); err != nil {
 		return fmt.Errorf("error executing ansible-runner: err=%w", err)
 	}
 
 	defer func() {
-		log.Infof("run complete: status=%v", r.Status)
+		slog.Info("run complete:",
+			"pid", ansibleRunnerCmd.Process.Pid,
+			"status", r.Status,
+		)
 	}()
 
 	if err := r.processStatus(); err != nil {
@@ -128,10 +138,12 @@ func (r *Runner) Run(playbook []byte) error {
 // handleJobEvent is the handler function invoked each time a job_event file is
 // written to the job_events directory.
 func (r *Runner) handleJobEvent(event notify.EventInfo) {
-	if strings.HasSuffix(event.Path(), ".json") && !strings.Contains(event.Path(), "partial") {
-		data, err := os.ReadFile(event.Path())
+	eventPath := event.Path()
+	if strings.HasSuffix(event.Path(), ".json") && !strings.Contains(eventPath, "partial") {
+		slog.Info("received job event:", "path", eventPath)
+		data, err := os.ReadFile(eventPath)
 		if err != nil {
-			log.Errorf("cannot read file: file=%v error=%v", event.Path(), err)
+			slog.Error("cannot read file:", "path", eventPath, "err", err)
 			return
 		}
 
@@ -143,12 +155,9 @@ func (r *Runner) handleJobEvent(event notify.EventInfo) {
 		// still be included in the data structure.
 		var ansibleEvent map[string]any
 		if err := json.Unmarshal(data, &ansibleEvent); err != nil {
-			log.Errorf("cannot unmarshal data: data=%v error=%v", data, err)
+			slog.Error("cannot unmarshal data:", "data", data, "err", err)
 			return
 		}
-
-		// log the full event
-		log.Debugf("received job event: %v", prettyJson(data))
 
 		eventData, ok := ansibleEvent["event_data"]
 		if !ok {
@@ -177,7 +186,7 @@ func (r *Runner) handleJobEvent(event notify.EventInfo) {
 
 		modifiedData, err := json.Marshal(ansibleEvent)
 		if err != nil {
-			log.Errorf("cannot marshal JSON: err=%v", err)
+			slog.Error("cannot marshal JSON:", "err", err)
 			return
 		}
 
@@ -185,13 +194,13 @@ func (r *Runner) handleJobEvent(event notify.EventInfo) {
 
 		if err != nil {
 			// problem filtering, return original event
-			log.Errorf("error filtering job event: err=%v", err)
-			log.Info("sending unfiltered job event...")
+			slog.Warn("could not filter job event:", "err", err)
+			slog.Warn("sending unfiltered job event")
 			filteredModifiedData = modifiedData
 		}
 
 		r.events <- filteredModifiedData
-		log.Debugf("event sent: event=%v", prettyJson(filteredModifiedData))
+		slog.Debug("sent job event:", "event", filteredModifiedData)
 	}
 }
 
@@ -222,13 +231,13 @@ func (r *Runner) watchJobEvents() {
 	defer close(watchedEvents)
 
 	if err := notify.Watch(r.jobEventsPath, watchedEvents, notify.InMovedTo); err != nil {
-		log.Errorf("cannot watch path for events: path=%v err=%v", r.jobEventsPath, err)
+		slog.Error("cannot watch path for events:", "path", r.jobEventsPath, "err", err)
 		return
 	}
 	defer notify.Stop(watchedEvents)
 
-	log.Tracef("start watching for job events: path=%v", r.jobEventsPath)
-	defer log.Tracef("stop watching for job events: path=%v", r.jobEventsPath)
+	slog.Info("start watching for job events:", "path", r.jobEventsPath)
+	defer slog.Info("stop watching for job events:", "path", r.jobEventsPath)
 
 	for {
 		select {
@@ -255,19 +264,4 @@ func filterJobEvent(jobEventData []byte) ([]byte, error) {
 	}
 
 	return filteredData, nil
-}
-
-// prettyJson pretty-prints a given JSON byte array
-func prettyJson(jsonBytes []byte) string {
-	var jsonObject map[string]any
-	if err := json.Unmarshal(jsonBytes, &jsonObject); err != nil {
-		log.Errorf("cannot unmarshal JSON: err=%v", err)
-		return ""
-	}
-	pretty, err := json.MarshalIndent(jsonObject, "", "\t")
-	if err != nil {
-		log.Errorf("cannot marshal JSON: err=%v", err)
-		return fmt.Sprintf("%v", jsonObject)
-	}
-	return string(pretty)
 }

--- a/internal/ansible/event_manager.go
+++ b/internal/ansible/event_manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime/multipart"
 	"net/textproto"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
 	"github.com/redhatinsights/yggdrasil/worker"
-	"github.com/subpop/go-log"
 )
 
 // createUuidFunc is a function that returns a UUID, typically uuid.New(),
@@ -76,7 +76,7 @@ func (e *EventManager) TransmitCachedEvents(done chan struct{}) {
 			// Transmit one final batch of all events.
 			e.cachedEventsLock.RLock()
 			if err := e.transmitEvents(e.cachedEvents); err != nil {
-				log.Errorf("cannot transmit events: err=%v", err)
+				slog.Error("cannot transmit events:", "err", err)
 			}
 			e.cachedEventsLock.RUnlock()
 			return
@@ -108,13 +108,15 @@ func (e *EventManager) TransmitCachedEvents(done chan struct{}) {
 
 			cachedEvents := append([]json.RawMessage{}, e.cachedEvents[batchStart:batchEnd]...)
 			e.cachedEventsLock.RUnlock()
-			log.Debugf(
-				"transmitting cached events: batchStart=%v batchEnd=%v",
+			slog.Info(
+				"transmitting cached events:",
+				"batchStart",
 				batchStart,
+				"batchEnd",
 				batchEnd,
 			)
 			if err := e.transmitEvents(cachedEvents); err != nil {
-				log.Errorf("cannot transmit events: err=%v", err)
+				slog.Error("cannot transmit events:", "err", err)
 				continue
 			}
 
@@ -143,7 +145,7 @@ func (e *EventManager) transmitEvents(events []json.RawMessage) error {
 		"runner-events",
 	)
 	if err != nil {
-		return fmt.Errorf("cannot build request body: err=%v", err)
+		return fmt.Errorf("cannot build request body: err=%w", err)
 	}
 
 	responseCode, responseMetadata, responseBody, err := e.worker.Transmit(
@@ -156,14 +158,14 @@ func (e *EventManager) transmitEvents(events []json.RawMessage) error {
 		requestBody.Bytes(),
 	)
 	if err != nil {
-		return fmt.Errorf("cannot transmit data: err=%v", err)
+		return fmt.Errorf("cannot transmit data: err=%w", err)
 	}
-	log.Debugf(
-		"received response: code=%v responseMetadata=%v",
-		responseCode,
-		responseMetadata,
+	slog.Info(
+		"received response:",
+		"responseCode", responseCode,
+		"responseMetadata", responseMetadata,
+		"responseBody", string(responseBody),
 	)
-	log.Tracef("responseBody=%v", string(responseBody))
 
 	if responseCode >= 400 {
 		// return an error if HTTP status code is 400 and up
@@ -253,7 +255,7 @@ func buildRequestBody(body string, filename string) (*bytes.Buffer, string, erro
 	defer func() {
 		closeErr := writer.Close()
 		if closeErr != nil {
-			log.Errorf("cannot close request body writer: %v", closeErr)
+			slog.Error("cannot close request body writer:", "err", closeErr)
 		}
 	}()
 

--- a/main.go
+++ b/main.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/constants"
 	"github.com/redhatinsights/yggdrasil/worker"
-	"github.com/subpop/go-log"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
 )
@@ -63,7 +64,11 @@ func main() {
 	app.Action = mainAction
 
 	if err := app.Run(os.Args); err != nil {
-		log.Fatal(err)
+		// previously called log.Fatal, equivalent to print and os.Exit(1)
+		// https://github.com/subpop/go-log/blob/ef6a7ef3d8f068b486fce9d933c04ef88a6003ea/log.go#L386
+		// https://pkg.go.dev/log#Fatal
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }
 
@@ -83,11 +88,11 @@ func beforeAction(ctx *cli.Context) error {
 
 func mainAction(ctx *cli.Context) error {
 	loadConfigFromContext(ctx)
-	level, err := log.ParseLevel(config.DefaultConfig.LogLevel)
+	level, err := parseLevel(config.DefaultConfig.LogLevel)
 	if err != nil {
-		return cli.Exit(fmt.Errorf("cannot unmarshal log-level: %w", err), 1)
+		return cli.Exit(err, 1)
 	}
-	log.SetLevel(level)
+	slog.SetLogLoggerLevel(level)
 
 	w, err := worker.NewWorker(config.DefaultConfig.Directive, true, nil, nil, rx, nil)
 	if err != nil {
@@ -114,4 +119,25 @@ func loadConfigFromContext(ctx *cli.Context) {
 	config.DefaultConfig.VerifyPlaybook = ctx.Bool(config.FlagNameVerifyPlaybook)
 	config.DefaultConfig.ResponseInterval = ctx.Duration(config.FlagNameResponseInterval)
 	config.DefaultConfig.BatchEvents = ctx.Int(config.FlagNameBatchEvents)
+}
+
+// parseLevel parses the log level string from the config to an slog.Level
+func parseLevel(str string) (slog.Level, error) {
+	switch strings.ToUpper(str) {
+	case "ERROR":
+		return slog.LevelError, nil
+	case "WARN":
+		return slog.LevelWarn, nil
+	case "INFO":
+		return slog.LevelInfo, nil
+	case "DEBUG":
+		return slog.LevelDebug, nil
+	case "TRACE":
+		// slog has no "trace" level by default, use LevelDebug
+		// We've migrated all prior "trace" level log calls to other levels,
+		// but trace should still be a valid config option.
+		return slog.LevelDebug, nil
+	}
+
+	return new(slog.LevelVar).Level(), fmt.Errorf("cannot parse log level: %v", str)
 }

--- a/worker.go
+++ b/worker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"strings"
 	"sync"
@@ -14,7 +15,6 @@ import (
 	"github.com/redhatinsights/rhc-worker-playbook/internal/ansible"
 	"github.com/redhatinsights/rhc-worker-playbook/internal/config"
 	"github.com/redhatinsights/yggdrasil/worker"
-	"github.com/subpop/go-log"
 )
 
 var playbookAlreadyRunning sync.Mutex
@@ -27,8 +27,8 @@ func rx(
 	metadata map[string]string,
 	data []byte,
 ) error {
-	log.Infof("message received: message-id=%v", id)
-	defer log.Infof("message finished: message-id=%v", id)
+	slog.Info("message received:", "message-id", id)
+	defer slog.Info("message finished:", "message-id", id)
 
 	// Get returnURL from message metadata
 	returnURL, has := metadata["return_url"]
@@ -46,7 +46,7 @@ func rx(
 	// value loaded from the configuration file.
 	responseIntervalString, has := metadata["response_interval"]
 	if !has {
-		log.Warn("metadata missing response_interval, defaulting to 300")
+		slog.Warn("metadata missing response_interval, defaulting to 300")
 		responseIntervalString = "300"
 	}
 	responseInterval, err := time.ParseDuration(responseIntervalString + "s")
@@ -169,6 +169,7 @@ func rx(
 // standard input. If the playbook passes verification, the playbook, stripped
 // of "insights_signature" variables is returned.
 func verifyPlaybook(data []byte) ([]byte, error) {
+	slog.Info("verifying playbook")
 
 	stdin := bytes.NewReader(data)
 	stdoutb := new(bytes.Buffer)
@@ -184,6 +185,12 @@ func verifyPlaybook(data []byte) ([]byte, error) {
 	rhcPlaybookVerifierCmd.Stdin = stdin
 	rhcPlaybookVerifierCmd.Stdout = stdoutb
 	rhcPlaybookVerifierCmd.Stderr = stderrb
+
+	slog.Info("launching rhc-playbook-verifier subprocess")
+	slog.Debug("launching with parameters:",
+		"args", rhcPlaybookVerifierCmd.Args,
+		"env", rhcPlaybookVerifierCmd.Env,
+		"stdin", string(data))
 
 	err := rhcPlaybookVerifierCmd.Run()
 
@@ -202,7 +209,7 @@ func verifyPlaybook(data []byte) ([]byte, error) {
 	}
 
 	// verification succeeds, log here
-	log.Info("Playbook verified.")
+	slog.Info("playbook verified.")
 
 	// Register a custom unmarshaler to support the YAML 1.1 boolean types
 	// "yes/no" and "on/off".

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"log/slog"
 	"os"
 	"os/exec"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/subpop/go-log"
 )
 
 func readFile(t *testing.T, file string) []byte {
@@ -51,7 +51,7 @@ func TestVerifyPlaybook(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			log.SetLevel(log.LevelDebug)
+			slog.SetLogLoggerLevel(slog.LevelDebug)
 			got, err := verifyPlaybook(test.input.playbook)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
This PR addresses the deprecated `go-log` package and replaces its calls with `slog`.

A few key points and differences to note:

- The `go-log` calls made extensive use of functions with `fmt.Sprintf`-like parameters. This is not available in `slog`, and instead you must provide key-value pairs as alternating arguments. This migration was easily done for the most part, since the prior logging already followed the output style that `slog` generates. In some cases, `fmt.Sprintf` was used instead where the key-value syntax was inconvenient (such as logging prettified JSON strings)

- `slog` does not include `Fatal` or `Trace` logging levels or functions. `Fatal` was replaced here by an equivalent "log-and-exit" approach. `Trace` was scarcely used in our case, and in my opinion, the events at the `trace` level should have been at a different level anyway. To maintain compatibility with configuration files on upgrade, `trace` is allowed as a configurable level, but will translate to `debug`.

- Some additional log messages were added, such as those indicating process state (file writes, subprocess calls) -- see [RHEL-146059](https://redhat.atlassian.net/browse/RHEL-146059). For example:
  ```
  2026/06/17 14:45:12 INFO launching python3 (ansible-runner) subprocess
  2026/06/17 14:45:12 DEBUG launching with parameters: args="[/usr/bin/python3 -m ansible_runner run --ident fa611932-1af4-4417-ac07-935f079e9b2b --playbook /var/lib/rhc-worker-playbook/fa611932-1af4-4417-ac07-935f079e9b2b.yaml /var/lib/rhc-worker-playbook/runs]" env="[PATH=/sbin:/bin:/usr/sbin:/usr/bin PYTHONPATH=/usr/lib64/rhc-worker-playbook PYTHONDONTWRITEBYTECODE=1 ANSIBLE_HOME=/var/lib/rhc-worker-playbook/ansible-home ANSIBLE_REMOTE_TMP=/var/lib/rhc-worker-playbook/ansible-home/remote-tmp ANSIBLE_COLLECTIONS_PATH=/usr/share/rhc-worker-playbook/ansible/collections/ansible_collections]"
  ```

- Some log messages had their log levels changed to improve log comprehension at different levels.

- To avoid overloading the log with JSON bodies, I reduced the `received job event:` message containing the full Ansible job event data to that of the path of the job event on disk. The `sent job event:` logged to DEBUG after filtering is unchanged, however `prettyJson` has been removed since `slogging` attributes do not support formatting. For example:
   ```
   2026/06/25 11:04:18 INFO received job event: path=/var/lib/rhc-worker-playbook/runs/artifacts/04f80d9b-e8f4-44be-afaf-7aad3beaee87/job_events/4-52540071-6c31-9e36-3efd-000000000001.json
   2026/06/25 11:04:18 DEBUG sent job event: event="{\"counter\":4,\"end_line\":4,\"event\":\"playbook_on_play_start\",\"event_data\":{\"crc_dispatcher_correlation_id\":\"04f80d9b-e8f4-44be-afaf-7aad3beaee87\",\"playbook\":\"/var/lib/rhc-worker-playbook/04f80d9b-e8f4-44be-afaf-7aad3beaee87.yaml\",\"playbook_uuid\":\"74ff3e83-d496-4618-a660-fd384d747c28\"},\"start_line\":2,\"stdout\":\"\\r\\nPLAY [ping] ********************************************************************\",\"uuid\":\"52540071-6c31-9e36-3efd-000000000001\",\"runner_ident\":\"04f80d9b-e8f4-44be-afaf-7aad3beaee87\"}"
   ```


- `go-log` still remains as an "indirect" dependency since `yggdrasil` has not yet replaced it.

[RHEL-146059]: https://redhat.atlassian.net/browse/RHEL-146059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ