### PR TITLE
refactor(RHINENG-29633): move custom yaml logic to init

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -17,7 +17,38 @@ import (
 	"github.com/redhatinsights/yggdrasil/worker"
 )
 
+type Playbook struct {
+	Name   string          `yaml:"name"`
+	Hosts  string          `yaml:"hosts"`
+	Become bool            `yaml:"become"`
+	Vars   map[string]any  `yaml:"vars"`
+	Tasks  []yaml.MapSlice `yaml:"tasks"`
+}
+
 var playbookAlreadyRunning sync.Mutex
+
+func init() {
+	// Register a custom unmarshaler to support the YAML 1.1 boolean types
+	// "yes/no" and "on/off".
+
+	// full spec: https://yaml.org/type/bool.html
+	// allowed values:
+	//  y|Y|yes|Yes|YES|n|N|no|No|NO
+	// |true|True|TRUE|false|False|FALSE
+	// |on|On|ON|off|Off|OFF
+	yaml.RegisterCustomUnmarshaler[bool](func(b1 *bool, b2 []byte) error {
+		toString := strings.TrimSpace(string(b2))
+		switch toString {
+		case "y", "Y", "yes", "Yes", "YES", "true", "True", "TRUE", "on", "On", "ON":
+			*b1 = true
+		case "n", "N", "no", "No", "NO", "false", "False", "FALSE", "off", "Off", "OFF":
+			*b1 = false
+		default:
+			return fmt.Errorf("unable to parse boolean: %v", toString)
+		}
+		return nil
+	})
+}
 
 func rx(
 	w *worker.Worker,
@@ -211,34 +242,6 @@ func verifyPlaybook(data []byte) ([]byte, error) {
 	// verification succeeds, log here
 	slog.Info("playbook verified.")
 
-	// Register a custom unmarshaler to support the YAML 1.1 boolean types
-	// "yes/no" and "on/off".
-	yaml.RegisterCustomUnmarshaler[bool](func(b1 *bool, b2 []byte) error {
-		if strings.ToLower(string(b2)) == "yes" || strings.ToLower(string(b2)) == "on" ||
-			strings.ToLower(string(b2)) == "true" {
-			*b1 = true
-		} else {
-			*b1 = false
-		}
-		return nil
-	})
-
-	// Register a custom marshaler to support the YAML 1.1 boolean types
-	// "yes/no" and "on/off".
-	yaml.RegisterCustomMarshaler[bool](func(b bool) ([]byte, error) {
-		if b {
-			return []byte("yes"), nil
-		}
-		return []byte("no"), nil
-	})
-
-	type Playbook struct {
-		Name   string                 `yaml:"name"`
-		Hosts  string                 `yaml:"hosts"`
-		Become bool                   `yaml:"become"`
-		Vars   map[string]interface{} `yaml:"vars"`
-		Tasks  []yaml.MapSlice        `yaml:"tasks"`
-	}
 	var playbooks []Playbook
 	if err := yaml.UnmarshalWithOptions(stdout, &playbooks); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal playbook: %v", err)

--- a/worker_test.go
+++ b/worker_test.go
@@ -4,8 +4,10 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
+	"github.com/goccy/go-yaml"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -62,4 +64,250 @@ func TestVerifyPlaybook(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestYAMLCustomUnmarshaler(t *testing.T) {
+	t.Run("Custom unmarshaler can parse 1.1 booleans", func(t *testing.T) {
+
+		testTruePlaybooks := [][]byte{
+			[]byte(`- name: y Playbook
+  hosts: localhost
+  become: y
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: Y Playbook
+  hosts: localhost
+  become: Y
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: yes Playbook
+  hosts: localhost
+  become: yes
+  vars: {}
+  tasks: []
+`),
+			[]byte(`- name: Yes Playbook
+  hosts: localhost
+  become: Yes
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: YES Playbook
+  hosts: localhost
+  become: YES
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: on Playbook
+  hosts: localhost
+  become: on
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: On Playbook
+  hosts: localhost
+  become: On
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: ON Playbook
+  hosts: localhost
+  become: ON
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: true Playbook
+  hosts: localhost
+  become: true
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: True Playbook
+  hosts: localhost
+  become: True
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: TRUE Playbook
+  hosts: localhost
+  become: TRUE
+  vars: {}
+  tasks: []
+`)}
+
+		testFalsePlaybooks := [][]byte{
+			[]byte(`- name: n Playbook
+  hosts: localhost
+  become: n
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: N Playbook
+  hosts: localhost
+  become: N
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: no Playbook
+  hosts: localhost
+  become: no
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: No Playbook
+  hosts: localhost
+  become: No
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: NO Playbook
+  hosts: localhost
+  become: NO
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: off Playbook
+  hosts: localhost
+  become: off
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: Off Playbook
+  hosts: localhost
+  become: Off
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: OFF Playbook
+  hosts: localhost
+  become: OFF
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: false Playbook
+  hosts: localhost
+  become: false
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: False Playbook
+  hosts: localhost
+  become: False
+  vars: {}
+  tasks: []
+`),
+
+			[]byte(`- name: FALSE Playbook
+  hosts: localhost
+  become: FALSE
+  vars: {}
+  tasks: []
+`)}
+
+		testErrorPlaybook := []byte(`- name: Error Playbook
+  hosts: localhost
+  become: death, destroyer of worlds
+  vars: {}
+  tasks: []
+`)
+
+		testingMatrix := []struct {
+			playbooks [][]byte
+			want      bool
+		}{
+			{
+				playbooks: testTruePlaybooks,
+				want:      true,
+			}, {
+				playbooks: testFalsePlaybooks,
+				want:      false,
+			},
+		}
+
+		for _, testValues := range testingMatrix {
+			for _, testPb := range testValues.playbooks {
+				var pbs []Playbook
+				if err := yaml.UnmarshalWithOptions(testPb, &pbs); err != nil {
+					t.Errorf("%v", err)
+				}
+
+				got := pbs[0].Become
+				if got != testValues.want {
+					t.Errorf("\ngot:\n%v\nwant:\n%v", got, testValues.want)
+				}
+			}
+		}
+
+		// finally, make sure it errors on invalid values
+		var playbooks []Playbook
+		err := yaml.UnmarshalWithOptions(testErrorPlaybook, &playbooks)
+
+		if err == nil {
+			t.Errorf("there should have been a YAML parsing error: %v", testErrorPlaybook)
+		}
+
+		if !strings.Contains(err.Error(), "unable to parse boolean") {
+			t.Errorf("unknown error: %v", err)
+		}
+
+	})
+
+	t.Run("Marshaler serializes yaml with become: true or become: false", func(t *testing.T) {
+		truePlaybook := []Playbook{
+			{
+				Name:   "True Playbook",
+				Hosts:  "localhost",
+				Become: true,
+				Vars:   map[string]any{},
+				Tasks:  []yaml.MapSlice{},
+			},
+		}
+
+		falsePlaybook := []Playbook{
+			{
+				Name:   "False Playbook",
+				Hosts:  "localhost",
+				Become: false,
+				Vars:   map[string]any{},
+				Tasks:  []yaml.MapSlice{},
+			},
+		}
+
+		playbookData, err := yaml.MarshalWithOptions(truePlaybook, yaml.IndentSequence(false))
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+		if !strings.Contains(string(playbookData), "become: true") {
+			t.Errorf("incorrect marshaling: %v", playbookData)
+		}
+
+		playbookData, err = yaml.MarshalWithOptions(falsePlaybook, yaml.IndentSequence(false))
+		if err != nil {
+			t.Errorf("%v", err)
+		}
+		if !strings.Contains(string(playbookData), "become: false") {
+			t.Errorf("incorrect marshaling: %v", playbookData)
+		}
+
+	})
 }


### PR DESCRIPTION
- Fix the unmarshaler to STRIP WHITESPACE! Previously the unmarshaler didn't work properly and would always evaluate to `false` because of trailing newlines in the function argument.
- Move custom unmarshaler registrations to `init()`
   - This is currently being done on every call to `verifyPlaybook` which is unnecessary, it only needs to be done once
- Rescope `Playbook` struct to top level