### PR TITLE
refactor(RHINENG-22587): better yaml validation

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -17,10 +17,10 @@ import (
 	"github.com/redhatinsights/yggdrasil/worker"
 )
 
-type Playbook struct {
+type Play struct {
 	Name   string          `yaml:"name"`
 	Hosts  string          `yaml:"hosts"`
-	Become bool            `yaml:"become"`
+	Become *bool           `yaml:"become,omitempty"`
 	Vars   map[string]any  `yaml:"vars"`
 	Tasks  []yaml.MapSlice `yaml:"tasks"`
 }
@@ -176,6 +176,22 @@ func rx(
 			return verifyPlaybookError
 		}
 	}
+
+	// Strip the signature - also verifies the data is YAML
+	data, err = stripSignature(data)
+	if err != nil {
+		stripSignatureError := err
+
+		if err := eventManager.SendExecutorOnFailedEvent(
+			"ANSIBLE_YAML_VALIDATION_FAILED",
+			stripSignatureError,
+		); err != nil {
+			return errors.Join(stripSignatureError, err)
+		}
+
+		return stripSignatureError
+	}
+
 	// Create the playbook runner and run the playbook
 	err = ansible.NewRunner(correlationId, events).Run(data)
 
@@ -195,10 +211,10 @@ func rx(
 	return nil
 }
 
-// verifyPlaybook calls out via subprocess to insights-client's
-// ansible.playbook_verifier Python module, passes data as the process's
-// standard input. If the playbook passes verification, the playbook, stripped
-// of "insights_signature" variables is returned.
+// verifyPlaybook calls out via subprocess to rhc-playbook-verifier,
+// and passes data as the process's standard input.
+// If the playbook passes verification, the stdout
+// of rhc-playbook-verifier is returned
 func verifyPlaybook(data []byte) ([]byte, error) {
 	slog.Info("verifying playbook")
 
@@ -242,15 +258,26 @@ func verifyPlaybook(data []byte) ([]byte, error) {
 	// verification succeeds, log here
 	slog.Info("playbook verified.")
 
-	var playbooks []Playbook
-	if err := yaml.UnmarshalWithOptions(stdout, &playbooks); err != nil {
+	return stdout, nil
+}
+
+// stripSignature will confirm the playbook is YAML and return
+// the playbook stripped of "insights_signature" variables
+func stripSignature(data []byte) ([]byte, error) {
+	var plays []Play
+	if err := yaml.UnmarshalWithOptions(data, &plays); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal playbook: %v", err)
 	}
-	// ansible-runner returns errors when handed binary field values, so
-	// remove it before handing off the playbook to ansible-runner.
-	delete(playbooks[0].Vars, "insights_signature")
 
-	playbookData, err := yaml.MarshalWithOptions(playbooks, yaml.IndentSequence(false))
+	// ansible-runner returns errors when handed binary field values, so
+	// remove the signatures from the plays before handing off the playbook
+	// to ansible-runner.
+	for _, play := range plays {
+		delete(play.Vars, "insights_signature")
+		delete(play.Vars, "insights_signature_exclude")
+	}
+
+	playbookData, err := yaml.MarshalWithOptions(plays, yaml.IndentSequence(false))
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal playbook: %v", err)
 	}

--- a/worker_test.go
+++ b/worker_test.go
@@ -22,6 +22,7 @@ func readFile(t *testing.T, file string) []byte {
 func TestVerifyPlaybook(t *testing.T) {
 	_, err := exec.LookPath("/usr/libexec/rhc-playbook-verifier")
 	if err != nil {
+		// this NEEDS to be on the system to properly test this functionality
 		t.Skip("rhc-playbook-verifier is not installed")
 	}
 
@@ -39,20 +40,45 @@ func TestVerifyPlaybook(t *testing.T) {
 			}{
 				playbook: readFile(t, "./testdata/insights_remove.yml"),
 			},
-			want: []byte(`- name: Insights Disable
+			want: []byte(`# This playbook will take care of all steps required to disable
+# Insights Client
+- name: Insights Disable
   hosts: localhost
   become: yes
   vars:
     insights_signature_exclude: /hosts,/vars/insights_signature
+    insights_signature: !!binary |
+      TFMwdExTMUNSVWRKVGlCUVIxQWdVMGxIVGtGVVZWSkZMUzB0TFMwS1ZtVnljMmx2YmpvZ1IyNTFV
+      RWNnZGpFS0NtbFJTV05DUVVGQ1EwRkJSMEpSU20xdGIwRmtRVUZ2U2tWTmRuYzFPRVFyYWpWd1Rr
+      UlpTVkF2YVVwV2VWWnZkbE5LYTNwdUwweFNjMVpEVGtGWVQzY0tXa3QzYnpBM1RXMTFiVFJQZFdG
+      c2MwVTFiakZHUTBSd0wyNW5URWhQYjBGT2JXZG9lV2RaVVdnclNYSk5SVFphTW5kNGRtUnVVMUU1
+      Um5oaFZEQlJRUW8wYURoNVJHaEhXWGw0TVhwUlRYbGtRV3QzUmtwRmFsVjJabTVoVmpNM2RFazFR
+      MVJtU1RacU5HaEhaREJpVFROclNIVk9hR3RSYzNWbmJIZFJNMlV5Q21WdlUzVkZjVkpZVDBwbkwz
+      bEdVa05GYkRONGIzSllUSEoxU3psdFRIRlRTR05PZFZWSWJWVjBPWEpUY0ROalpsTjZUSHBHV2l0
+      WFJWcDNXWGw1TmpNS1ZXSnBaVzAxUzFoUVpESk9ZbE5YVHpseFZpOU5kaTl1Y25WdVlXRnpRVkJW
+      T0dWa2MxRjJTWFJGZVVzemJqSlNWMnhMWkhCbFEzUXplV3RsWjBFeGNRcFhkRXRJVWxVNU9XRmla
+      Mkp6VUZoUVJ6WXdPV1ZOWkdGTlIxZEZlWHBuVmpsV2NYSkxTR3BhVjJacGNtRTNTVUptTDFOVGMy
+      cHZSMkpRUmxWR015OXFDaTlCVFUxdlRHaHFWbEI0WjNaTFZXaFdTV2hwUVd4VmFuaFBNM0JKTVRK
+      emVrOXRiMGxFUkdKb2FHeE5lRGd5YzBkRWFuSktPRFZVWlUweGNuQjRZbklLVmxWemFraFpaRzQx
+      UW10amVISm5aWGhJWVN0SmVFMXFhbXBEVmt4WmNUTlFkV2s1Um05dlF6TmpNRFo1ZFRBME4xcERW
+      R2RoWTFSbFVuTXljMWhWWWdvM1pWWkVaMHh0ZG1sRVNFdGhLMVp2UmxOa01YQklSRVEzY0RGSFJY
+      bFlUMjV1YzI1a05GUktVblZuT0VVMWJUUm5aSEp3VVRSTGNrY3pUR3RXYXpKQkNsQldlaXR1UzFO
+      VmJuWkVRbVJ3YTNoT05EZDBaM014TjNOcFlqUm9Sak5JVFhGRWNWRk5abFphZWtwck4ySlFlRFZ5
+      WlZGU1FXMUtPVUZYTkcwMlVEa0tURFZuVlRGSWRIbHBaa05zZEV4cllWcHlRVkJtVG1KRmIycGxk
+      VVEwZG5CcU9EZEVPR2gxT0dJd05EaDBkeTlaVlhjdmIzQTJjMk5wWkVaM2VHdFRlUXBYZVZCRVFV
+      bDJOME4xU2xwc2JFYzVUR05KVVFvOWRYbENaUW90TFMwdExVVk9SQ0JRUjFBZ1UwbEhUa0ZVVlZK
+      RkxTMHRMUzBL
   tasks:
-  - name: Disable the insights-client
-    command: insights-client --disable-schedule
+    - name: Disable the insights-client
+      command: insights-client --disable-schedule
+
 `),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+
 			slog.SetLogLoggerLevel(slog.LevelDebug)
 			got, err := verifyPlaybook(test.input.playbook)
 			if err != nil {
@@ -67,6 +93,13 @@ func TestVerifyPlaybook(t *testing.T) {
 }
 
 func TestYAMLCustomUnmarshaler(t *testing.T) {
+
+	// initialize bool pointers for comparison
+	tru := new(bool)
+	*tru = true
+	fal := new(bool)
+	*fal = false
+
 	t.Run("Custom unmarshaler can parse 1.1 booleans", func(t *testing.T) {
 
 		testTruePlaybooks := [][]byte{
@@ -233,33 +266,33 @@ func TestYAMLCustomUnmarshaler(t *testing.T) {
 
 		testingMatrix := []struct {
 			playbooks [][]byte
-			want      bool
+			want      *bool
 		}{
 			{
 				playbooks: testTruePlaybooks,
-				want:      true,
+				want:      tru,
 			}, {
 				playbooks: testFalsePlaybooks,
-				want:      false,
+				want:      fal,
 			},
 		}
 
 		for _, testValues := range testingMatrix {
 			for _, testPb := range testValues.playbooks {
-				var pbs []Playbook
+				var pbs []Play
 				if err := yaml.UnmarshalWithOptions(testPb, &pbs); err != nil {
 					t.Errorf("%v", err)
 				}
 
 				got := pbs[0].Become
-				if got != testValues.want {
+				if *got != *testValues.want {
 					t.Errorf("\ngot:\n%v\nwant:\n%v", got, testValues.want)
 				}
 			}
 		}
 
 		// finally, make sure it errors on invalid values
-		var playbooks []Playbook
+		var playbooks []Play
 		err := yaml.UnmarshalWithOptions(testErrorPlaybook, &playbooks)
 
 		if err == nil {
@@ -273,21 +306,21 @@ func TestYAMLCustomUnmarshaler(t *testing.T) {
 	})
 
 	t.Run("Marshaler serializes yaml with become: true or become: false", func(t *testing.T) {
-		truePlaybook := []Playbook{
+		truePlaybook := []Play{
 			{
 				Name:   "True Playbook",
 				Hosts:  "localhost",
-				Become: true,
+				Become: tru,
 				Vars:   map[string]any{},
 				Tasks:  []yaml.MapSlice{},
 			},
 		}
 
-		falsePlaybook := []Playbook{
+		falsePlaybook := []Play{
 			{
 				Name:   "False Playbook",
 				Hosts:  "localhost",
-				Become: false,
+				Become: fal,
 				Vars:   map[string]any{},
 				Tasks:  []yaml.MapSlice{},
 			},
@@ -298,7 +331,7 @@ func TestYAMLCustomUnmarshaler(t *testing.T) {
 			t.Errorf("%v", err)
 		}
 		if !strings.Contains(string(playbookData), "become: true") {
-			t.Errorf("incorrect marshaling: %v", playbookData)
+			t.Errorf("incorrect marshaling: %v", string(playbookData))
 		}
 
 		playbookData, err = yaml.MarshalWithOptions(falsePlaybook, yaml.IndentSequence(false))
@@ -306,8 +339,108 @@ func TestYAMLCustomUnmarshaler(t *testing.T) {
 			t.Errorf("%v", err)
 		}
 		if !strings.Contains(string(playbookData), "become: false") {
-			t.Errorf("incorrect marshaling: %v", playbookData)
+			t.Errorf("incorrect marshaling: %v", string(playbookData))
 		}
 
+	})
+}
+
+func TestStripSignature(t *testing.T) {
+	t.Run("stripSignature returns the playbook with insights_signature removed from vars", func(t *testing.T) {
+		// this is the output of verifyPlaybook, complete playbook data
+		playbook := []byte(`# This playbook will take care of all steps required to disable
+# Insights Client
+- name: Insights Disable
+  hosts: localhost
+  become: yes
+  vars:
+    insights_signature_exclude: /hosts,/vars/insights_signature
+    insights_signature: !!binary |
+      TFMwdExTMUNSVWRKVGlCUVIxQWdVMGxIVGtGVVZWSkZMUzB0TFMwS1ZtVnljMmx2YmpvZ1IyNTFV
+      RWNnZGpFS0NtbFJTV05DUVVGQ1EwRkJSMEpSU20xdGIwRmtRVUZ2U2tWTmRuYzFPRVFyYWpWd1Rr
+      UlpTVkF2YVVwV2VWWnZkbE5LYTNwdUwweFNjMVpEVGtGWVQzY0tXa3QzYnpBM1RXMTFiVFJQZFdG
+      c2MwVTFiakZHUTBSd0wyNW5URWhQYjBGT2JXZG9lV2RaVVdnclNYSk5SVFphTW5kNGRtUnVVMUU1
+      Um5oaFZEQlJRUW8wYURoNVJHaEhXWGw0TVhwUlRYbGtRV3QzUmtwRmFsVjJabTVoVmpNM2RFazFR
+      MVJtU1RacU5HaEhaREJpVFROclNIVk9hR3RSYzNWbmJIZFJNMlV5Q21WdlUzVkZjVkpZVDBwbkwz
+      bEdVa05GYkRONGIzSllUSEoxU3psdFRIRlRTR05PZFZWSWJWVjBPWEpUY0ROalpsTjZUSHBHV2l0
+      WFJWcDNXWGw1TmpNS1ZXSnBaVzAxUzFoUVpESk9ZbE5YVHpseFZpOU5kaTl1Y25WdVlXRnpRVkJW
+      T0dWa2MxRjJTWFJGZVVzemJqSlNWMnhMWkhCbFEzUXplV3RsWjBFeGNRcFhkRXRJVWxVNU9XRmla
+      Mkp6VUZoUVJ6WXdPV1ZOWkdGTlIxZEZlWHBuVmpsV2NYSkxTR3BhVjJacGNtRTNTVUptTDFOVGMy
+      cHZSMkpRUmxWR015OXFDaTlCVFUxdlRHaHFWbEI0WjNaTFZXaFdTV2hwUVd4VmFuaFBNM0JKTVRK
+      emVrOXRiMGxFUkdKb2FHeE5lRGd5YzBkRWFuSktPRFZVWlUweGNuQjRZbklLVmxWemFraFpaRzQx
+      UW10amVISm5aWGhJWVN0SmVFMXFhbXBEVmt4WmNUTlFkV2s1Um05dlF6TmpNRFo1ZFRBME4xcERW
+      R2RoWTFSbFVuTXljMWhWWWdvM1pWWkVaMHh0ZG1sRVNFdGhLMVp2UmxOa01YQklSRVEzY0RGSFJY
+      bFlUMjV1YzI1a05GUktVblZuT0VVMWJUUm5aSEp3VVRSTGNrY3pUR3RXYXpKQkNsQldlaXR1UzFO
+      VmJuWkVRbVJ3YTNoT05EZDBaM014TjNOcFlqUm9Sak5JVFhGRWNWRk5abFphZWtwck4ySlFlRFZ5
+      WlZGU1FXMUtPVUZYTkcwMlVEa0tURFZuVlRGSWRIbHBaa05zZEV4cllWcHlRVkJtVG1KRmIycGxk
+      VVEwZG5CcU9EZEVPR2gxT0dJd05EaDBkeTlaVlhjdmIzQTJjMk5wWkVaM2VHdFRlUXBYZVZCRVFV
+      bDJOME4xU2xwc2JFYzVUR05KVVFvOWRYbENaUW90TFMwdExVVk9SQ0JRUjFBZ1UwbEhUa0ZVVlZK
+      RkxTMHRMUzBL
+  tasks:
+    - name: Disable the insights-client
+      command: insights-client --disable-schedule
+- name: ping
+  hosts: localhost
+  vars:
+    insights_signature_exclude: /hosts,/vars/insights_signature
+    insights_signature: !!binary |
+      TFMwdExTMUNSVWRKVGlCUVIxQWdVMGxIVGtGVVZWSkZMUzB0TFMwS1ZtVnljMmx2YmpvZ1IyNTFV
+      RWNnZGpFS0NtbFJTVlZCZDFWQldVaHBSM0ZqZG5jMU9FUXJhalZ3VGtGUmFrTXpRUzh6VVdwUVow
+      MXZTM0JYZFZVeWNuaExWVkpJYTI5VVRHVkdTRmczVDFkVU1Ya0tlRzR6WWtOMU1FeHdXRWhDWjBk
+      Vkt6VndTRFF3ZGswdmMzVlhjblJZYjNJckwydHRja3BFWkZWMU5IWkpaMmt4VW1aQmNsTmxabk5H
+      TTFCdlIxWnFjUW8yWkhVM1RuQmhOazlQT1cxWFJGWXZPRnBqYW14SVdrVkpUVU5OYlRKamRqQnVk
+      RmhuWTJwSmJrTmhlbmtyTVhkNmFHaExUMFJNV1RKTE9WZ3dPVUkzQ2xKR01HMWpjR0ZpUVZsclJH
+      ZHpWVVYyU0RCM2RXUTRkRkpuZW5sWVFXWTJZMmw0TTBabVoyOTVTa2d2ZUdFd01uWkZRbFZGUWxG
+      dFUzVlhjMEk0ZHpNS2FXaFVVVVpyVEN0NE1uQnliSGxXUWtWd2FqTnlRMmhZY3poMVVsbEJMeTlU
+      UjNka1owSndkMlpVWm01ckswUk5VVGRuUzJKbFYyVnhabFFyVlRNNUt3cGFaMGhoTW1WbFkzZFJh
+      MmhsVEUwNFkzVkhha012ZFVFNVpWSnhablJRY1RCcU0yVllNWGxGYjNOR1pHTldOekJuYzFJd1dH
+      TjBSazlDWTJWSVVXNXRDak4xVjBSVVRqRmllV0kyWVZaYVFqZzVUM1JWTjFCU1preHhSMVkyYjBj
+      MU5WQkZVRkV6VVRCSVRXMVRlRWt3WlRjNWNIUXhXVmxHUkhad2FtNXBjSGtLTjJ0aUwzbERObU5s
+      ZFZGTWNraHpLMjVSYkVKQ05VSk5OV0ZQVFN0emMwSkpSM1JJZGtWUFRqWTFOMGw2WlRKaGNqRnBj
+      bTh5Y1V4TVFXRkJVMHBrVEFwbU9ERmlPSGxFY1hCeVpFOVZaV1ZMYzBncldYazFhekZGVVUwdlRE
+      QXpjeTkzVm1wa1NqQktiV2xFVlhwd1pXa3dkVXRCYmxGUWRFdElRbFJsYmtsSENtRnBMMU5KYlRO
+      RWMxcHlNRTV4TnpsYVVWVjBiVEpYY0c5bGVrTkZla3ByVlN0eU4weFhjRWg1Y21SdE5VMVpOVzV4
+      TW1sb2JsaEVNRFZHTkhsbGIwVUtObmh4VlRGYWJDdERXSEZOYTNOblJUWklZV0l2VDFscVpHRmFX
+      VUZwUm5aUlJFOXhPVkU1V1ZVNE5rSnRXSGRwUzNoalltNVRWREJ6VnpZeFVUaFpWd3BWVUVSblpT
+      dFJMMHhSUFQwS1BVVnpWVWNLTFMwdExTMUZUa1FnVUVkUUlGTkpSMDVCVkZWU1JTMHRMUzB0Q2c9
+      PQ==
+  tasks:
+    - ping:
+`)
+
+		// should be the input but with the signature stripped
+		// the "become" boolean should also be set to strictly true/false
+		want := []byte(`- name: Insights Disable
+  hosts: localhost
+  become: true
+  vars: {}
+  tasks:
+  - name: Disable the insights-client
+    command: insights-client --disable-schedule
+- name: ping
+  hosts: localhost
+  vars: {}
+  tasks:
+  - ping: null
+`)
+
+		got, err := stripSignature(playbook)
+		if err != nil {
+			t.Error(err)
+		}
+		if !cmp.Equal(got, want) {
+			t.Errorf("\ngot:\n%v\nwant:\n%v", string(got), string(want))
+		}
+	})
+
+	t.Run("stripSignature returns an error when given invalid YAML", func(t *testing.T) {
+
+		got, err := stripSignature([]byte(`401 Unauthorized`))
+		if err == nil {
+			t.Error("there should have been a YAML parsing error")
+		}
+		if got != nil {
+			t.Error("first returned value should have been nil")
+		}
 	})
 }


### PR DESCRIPTION
- Separate "verify playbook" and "remove signature" steps into different functions
- Remove signature even when verification is off and add error handling path
   - The "remove signature" step also validates YAML as a bonus, so  if we run it even when verification is disabled we'll always know the YAML is, at least, YAML
- Rename the `Playbook` struct to `Play` to more accurately reflect the contents
- Change `Play.Become` from `bool` type to `*bool` to allow for optional `become` property in marshaled plays
- Remove `insights_signature_exclude` as part of the signature stripping
- Test the `stripSignature` function 